### PR TITLE
Add docs.rs coverage for opt-in feats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ concurrent = ["dep:crossbeam-utils", "dep:crossbeam-skiplist", "dep:parking_lot"
 cdc = ["concurrent"]
 
 [package.metadata.docs.rs]
-features = ["cdc"]
+features = ["cdc", "concurrent"]
 
 [[bench]]
 name = "stdlib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ serde = ["dep:serde"]
 concurrent = ["dep:crossbeam-utils", "dep:crossbeam-skiplist", "dep:parking_lot"]
 cdc = ["concurrent"]
 
+[package.metadata.docs.rs]
+features = ["cdc"]
+
 [[bench]]
 name = "stdlib"
 harness = false


### PR DESCRIPTION
docs.rs is helpful for exploring docs quickly. It would be helpful to expand its coverage via it's metaflag.