### PR TITLE
Update `ChangeEvent` enum API

### DIFF
--- a/src/cdc/change.rs
+++ b/src/cdc/change.rs
@@ -1,20 +1,19 @@
-
 pub enum ChangeEvent<T> {
     InsertAt {
         max_value: T,
         value: T,
-        index: usize
+        index: usize,
     },
     RemoveAt {
         max_value: T,
         value: T,
         index: usize,
     },
-    InsertNode{
+    InsertNode {
         max_value: T,
-        node: crate::concurrent::set::Node<T>
+        node: crate::concurrent::set::Node<T>,
     },
-    RemoveNode{
-        max_value: T
+    RemoveNode {
+        max_value: T,
     },
 }

--- a/src/cdc/change.rs
+++ b/src/cdc/change.rs
@@ -1,19 +1,37 @@
 pub enum ChangeEvent<T> {
+    /// Describes value insert event.
     InsertAt {
+        /// Max value that is used to identify node to remove value in.
         max_value: T,
+        /// Value that is inserted itself.
         value: T,
+        /// Index of a place in array to insert a value in.
         index: usize,
     },
+    /// Describes value remove event.
     RemoveAt {
+        /// Max value that is used to identify node to remove value from.
         max_value: T,
+        /// Value that is removed itself.
         value: T,
+        /// Index of a place in array to remove a value from.
         index: usize,
     },
-    InsertNode {
+    /// Describes node creation event.
+    CreateNode {
+        /// Initial max value.
         max_value: T,
-        node: crate::concurrent::set::Node<T>,
     },
+    /// Describes node removal event.
     RemoveNode {
+        /// Max value that is used to identify removed node.
         max_value: T,
+    },
+    /// Describes node split event.
+    SplitNode {
+        /// Max value that is used to identify node to split.
+        max_value: T,
+        /// Index of a value that will be last value in first split part.
+        split_index: usize,
     },
 }

--- a/src/cdc/change.rs
+++ b/src/cdc/change.rs
@@ -1,6 +1,20 @@
+
 pub enum ChangeEvent<T> {
-    InsertAt(T, T),
-    RemoveAt(T, T),
-    InsertNode(T, crate::concurrent::set::Node<T>),
-    RemoveNode(T),
+    InsertAt {
+        max_value: T,
+        value: T,
+        index: usize
+    },
+    RemoveAt {
+        max_value: T,
+        value: T,
+        index: usize,
+    },
+    InsertNode{
+        max_value: T,
+        node: crate::concurrent::set::Node<T>
+    },
+    RemoveNode{
+        max_value: T
+    },
 }

--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -354,26 +354,26 @@ mod tests {
     impl<K: Ord + Clone, V: Clone + PartialEq> PersistedBTreeMap<K, V> {
         fn persist(&mut self, event: &ChangeEvent<Pair<K, V>>) {
             match event {
-                ChangeEvent::InsertNode {
-                    max_value, node
-                } => {
+                ChangeEvent::InsertNode { max_value, node } => {
                     self.nodes
                         .insert(max_value.key.clone(), node.lock_arc().clone());
                 }
-                ChangeEvent::RemoveNode {
-                    max_value
-                } => {
+                ChangeEvent::RemoveNode { max_value } => {
                     self.nodes.remove(&max_value.key);
                 }
                 ChangeEvent::InsertAt {
-                    max_value, index, value
+                    max_value,
+                    index,
+                    value,
                 } => {
                     if let Some(node) = self.nodes.get_mut(&max_value.key) {
                         node.insert(*index, value.clone());
                     }
                 }
                 ChangeEvent::RemoveAt {
-                    max_value, index,value: _,
+                    max_value,
+                    index,
+                    value: _,
                 } => {
                     if let Some(node) = self.nodes.get_mut(&max_value.key) {
                         node.remove(*index);

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
+use std::iter::FusedIterator;
 use std::ops::RangeBounds;
 use std::{borrow::Borrow, sync::Arc};
-use std::iter::FusedIterator;
 
 use crossbeam_skiplist::SkipMap;
 use crossbeam_utils::sync::ShardedLock;
@@ -122,14 +122,11 @@ impl<T: Ord + Send + Clone + 'static> Operation<T> {
 
                             #[cfg(feature = "cdc")]
                             {
-                                let node_removal = ChangeEvent::RemoveNode {
-                                    max_value: old_max,
+                                let node_removal = ChangeEvent::RemoveNode { max_value: old_max };
+                                let node_insertion_1 = ChangeEvent::InsertNode {
+                                    max_value: max.clone(),
+                                    node: old_node.clone(),
                                 };
-                                let node_insertion_1 =
-                                    ChangeEvent::InsertNode {
-                                        max_value: max.clone(),
-                                        node: old_node.clone()
-                                    };
                                 cdc.push(node_removal);
                                 cdc.push(node_insertion_1);
                             }
@@ -153,11 +150,10 @@ impl<T: Ord + Send + Clone + 'static> Operation<T> {
 
                             #[cfg(feature = "cdc")]
                             {
-                                let node_insertion_2 =
-                                    ChangeEvent::InsertNode {
-                                        max_value: max.clone(),
-                                        node: new_node.clone()
-                                    };
+                                let node_insertion_2 = ChangeEvent::InsertNode {
+                                    max_value: max.clone(),
+                                    node: new_node.clone(),
+                                };
                                 cdc.push(node_insertion_2);
                             }
                             index.insert(max, new_node);
@@ -183,15 +179,13 @@ impl<T: Ord + Send + Clone + 'static> Operation<T> {
 
                                 #[cfg(feature = "cdc")]
                                 {
-                                    let node_removal = ChangeEvent::RemoveNode {
-                                        max_value: old_max,
-                                    };
+                                    let node_removal =
+                                        ChangeEvent::RemoveNode { max_value: old_max };
                                     cdc.push(node_removal);
-                                    let node_insertion =
-                                        ChangeEvent::InsertNode {
-                                            max_value: new_max.clone(),
-                                            node,
-                                        };
+                                    let node_insertion = ChangeEvent::InsertNode {
+                                        max_value: new_max.clone(),
+                                        node,
+                                    };
                                     cdc.push(node_insertion);
                                 }
 
@@ -215,7 +209,7 @@ impl<T: Ord + Send + Clone + 'static> Operation<T> {
                                 #[cfg(feature = "cdc")]
                                 {
                                     let node_removal = ChangeEvent::RemoveNode {
-                                        max_value: old_max.clone()
+                                        max_value: old_max.clone(),
                                     };
                                     cdc.push(node_removal);
                                 }
@@ -286,12 +280,10 @@ impl<T: Ord + Clone + Send> BTreeSet<T> {
                         if let Ok(_) = self.index_lock.try_write() {
                             #[cfg(feature = "cdc")]
                             {
-                                let node_insertion =
-                                    ChangeEvent::InsertNode {
-                                        max_value: value
-                                            .clone(),
-                                        node: first_node.clone()
-                                    };
+                                let node_insertion = ChangeEvent::InsertNode {
+                                    max_value: value.clone(),
+                                    node: first_node.clone(),
+                                };
                                 cdc.push(node_insertion);
                             }
 
@@ -314,14 +306,13 @@ impl<T: Ord + Clone + Send> BTreeSet<T> {
                     if node_guard.last().cloned() == old_max {
                         #[cfg(feature = "cdc")]
                         {
-                            let node_element_insertion =
-                                ChangeEvent::InsertAt {
-                                    max_value: old_max
-                                        .clone()
-                                        .expect("Max value should exist as Node is not empty"),
-                                    value: value.clone(),
-                                    index: idx,
-                                };
+                            let node_element_insertion = ChangeEvent::InsertAt {
+                                max_value: old_max
+                                    .clone()
+                                    .expect("Max value should exist as Node is not empty"),
+                                value: value.clone(),
+                                index: idx,
+                            };
                             cdc.push(node_element_insertion);
                         }
 
@@ -337,22 +328,20 @@ impl<T: Ord + Clone + Send> BTreeSet<T> {
                 } else {
                     #[cfg(feature = "cdc")]
                     {
-                        let node_element_removal =
-                            ChangeEvent::RemoveAt {
-                                max_value: old_max
-                                    .clone()
-                                    .expect("Max value should exist as Node is not empty"),
-                                value: value.clone(),
-                                index: idx,
-                            };
-                        let node_element_insertion =
-                            ChangeEvent::InsertAt {
-                                max_value: old_max
-                                    .clone()
-                                    .expect("Max value should exist as Node is not empty"),
-                                value: value.clone(),
-                                index: idx,
-                            };
+                        let node_element_removal = ChangeEvent::RemoveAt {
+                            max_value: old_max
+                                .clone()
+                                .expect("Max value should exist as Node is not empty"),
+                            value: value.clone(),
+                            index: idx,
+                        };
+                        let node_element_insertion = ChangeEvent::InsertAt {
+                            max_value: old_max
+                                .clone()
+                                .expect("Max value should exist as Node is not empty"),
+                            value: value.clone(),
+                            index: idx,
+                        };
                         cdc.push(node_element_removal);
                         cdc.push(node_element_insertion);
                     }
@@ -430,12 +419,12 @@ impl<T: Ord + Clone + Send> BTreeSet<T> {
                     if old_max.as_ref() == node_guard.last() {
                         #[cfg(feature = "cdc")]
                         {
-                            let node_element_removal =
-                                ChangeEvent::RemoveAt {
-                                    max_value: old_max.expect("Max value should exist as Node is not empty"),
-                                    value: deleted.clone(),
-                                    index: idx,
-                                };
+                            let node_element_removal = ChangeEvent::RemoveAt {
+                                max_value: old_max
+                                    .expect("Max value should exist as Node is not empty"),
+                                value: deleted.clone(),
+                                index: idx,
+                            };
                             cdc.push(node_element_removal);
                         }
 

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -24,7 +24,7 @@ pub trait NodeLike<T: Ord> {
     where
         T: Borrow<Q>;
     #[allow(dead_code)]
-    fn delete<Q: Ord + ?Sized>(&mut self, value: &Q) -> Option<T>
+    fn delete<Q: Ord + ?Sized>(&mut self, value: &Q) -> Option<(T, usize)>
     where
         T: Borrow<Q>;
     #[allow(dead_code)]
@@ -109,13 +109,13 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     }
     #[inline]
     fn insert(&mut self, value: T) -> (bool, usize) {
-        return match search(&self, &value) {
+        match search(&self, &value) {
             Ok(idx) => (false, idx),
             Err(idx) => {
                 self.insert(idx, value);
                 (true, idx)
             }
-        };
+        }
     }
     #[inline]
     fn contains<Q>(&self, value: &Q) -> bool
@@ -148,13 +148,13 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
         search_bound(&self, bound, from_start)
     }
     #[inline]
-    fn delete<Q>(&mut self, value: &Q) -> Option<T>
+    fn delete<Q>(&mut self, value: &Q) -> Option<(T, usize)>
     where
         T: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
         match search(&self, value) {
-            Ok(idx) => Some(self.remove(idx)),
+            Ok(idx) => Some((self.remove(idx), idx)),
             Err(_) => None,
         }
     }


### PR DESCRIPTION
`ChangeEvent` had to be updated because it contained `Node` as result (yes, I said it should be ok, but I think that will cause non consistent state if `Node` is updated while `ChangeEvent` is not processed). So I removed `Node` from event. Also I added `index` fields to `InsertAt` and `RemoveAt` variants to not call `binary_search` again, because value will be inserted in same place.