### PR TITLE
fix(#25): `BTreeMap::get` must be strict

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2150,7 +2150,9 @@ where
             .locate_value_cmp(|item: &Pair<K, V>| item.key.borrow() < key);
         if let Some(candidate_node) = self.set.inner.get(node_idx) {
             if let Some(candidate_value) = candidate_node.get(position_within_node) {
-                return Some((&candidate_value.key, &candidate_value.value));
+                if candidate_value.key.borrow() == key {
+                    return Some((&candidate_value.key, &candidate_value.value));
+                }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3908,6 +3908,18 @@ mod tests {
     }
 
     #[test]
+    fn test_map_get() {
+        let btree = BTreeMap::from_iter((0..(DEFAULT_INNER_SIZE * 10)).map(|i| (i, i)));
+
+        assert_eq!(btree.len(), DEFAULT_INNER_SIZE * 10);
+
+        for item in 0..DEFAULT_INNER_SIZE * 10 {
+            assert_eq!(btree.get(&(item + 1)), None);
+            assert_eq!(btree.get(&item), Some(&item));
+        }
+    }
+
+    #[test]
     fn test_get_contains_lower_bound() {
         let input: Vec<usize> = (0..(DEFAULT_INNER_SIZE + 1)).into_iter().rev().collect();
         let expected_output: Vec<usize> = (0..(DEFAULT_INNER_SIZE + 1)).collect();


### PR DESCRIPTION
Fixes #25.

`BTreeMap::get` search the near node with desired `key`, but doesn't check if that node has the same `key` as the provided