### PR TITLE
Add capacity() method

### DIFF
--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -321,6 +321,28 @@ impl<K: Send + Ord + Clone + 'static, V: Send + Clone + 'static> BTreeMap<K, V> 
     pub fn capacity(&self) -> usize {
         self.set.capacity()
     }
+    /// Returns the total number of nodes.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use indexset::concurrent::map::BTreeMap;
+    ///
+    /// let mut a = BTreeMap::with_maximum_node_size(16);
+    /// assert_eq!(a.node_count(), 16);
+    ///
+    /// a.insert(1, "a");
+    /// a.insert(2, "b");
+    ///
+    /// // Capacity remains the same until node is split or reallocated
+    /// assert_eq!(a.node_count(), 2);
+    /// ```
+    pub fn node_count(&self) -> usize {
+        self.set.node_count()
+    }
     /// Gets an iterator over the entries of the map, sorted by key.
     ///
     /// # Examples

--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -297,6 +297,30 @@ impl<K: Send + Ord + Clone + 'static, V: Send + Clone + 'static> BTreeMap<K, V> 
     pub fn len(&self) -> usize {
         self.set.len()
     }
+    /// Returns the total number of allocated slots across all internal nodes.
+    ///
+    /// This represents the number of key-value pairs the map can hold
+    /// without reallocating memory in its internal vectors.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use indexset::concurrent::map::BTreeMap;
+    ///
+    /// let mut a = BTreeMap::with_maximum_node_size(16);
+    /// assert_eq!(a.capacity(), 16);
+    ///
+    /// a.insert(1, "a");
+    /// a.insert(2, "b");
+    ///
+    /// // Capacity remains the same until node is split or reallocated
+    /// assert_eq!(a.capacity(), 16);
+    /// ```
+    pub fn capacity(&self) -> usize {
+        self.set.capacity()
+    }
     /// Gets an iterator over the entries of the map, sorted by key.
     ///
     /// # Examples

--- a/src/concurrent/multimap.rs
+++ b/src/concurrent/multimap.rs
@@ -358,6 +358,30 @@ impl<K: Send + Ord + Clone + 'static, V: Send + Clone + PartialEq + 'static> BTr
     pub fn len(&self) -> usize {
         self.set.len()
     }
+    /// Returns the total number of allocated slots across all internal nodes.
+    ///
+    /// This represents the number of key-value pairs the multimap can hold
+    /// without reallocating memory in its internal vectors.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use indexset::concurrent::multimap::BTreeMultiMap;
+    ///
+    /// let mut a = BTreeMultiMap::with_node_capacity(8);
+    /// assert_eq!(a.capacity(), 8);
+    ///
+    /// a.insert(1, "a");
+    /// a.insert(1, "b");
+    ///
+    /// // Capacity remains unchanged until reallocation occurs
+    /// assert_eq!(a.capacity(), 8);
+    /// ```
+    pub fn capacity(&self) -> usize {
+        self.set.capacity()
+    }
     /// Gets an iterator over the entries of the map, sorted by key.
     ///
     /// # Examples

--- a/src/concurrent/multimap.rs
+++ b/src/concurrent/multimap.rs
@@ -382,6 +382,28 @@ impl<K: Send + Ord + Clone + 'static, V: Send + Clone + PartialEq + 'static> BTr
     pub fn capacity(&self) -> usize {
         self.set.capacity()
     }
+    /// Returns the total number of nodes.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use indexset::concurrent::map::BTreeMap;
+    ///
+    /// let mut a = BTreeMap::with_maximum_node_size(16);
+    /// assert_eq!(a.node_count(), 16);
+    ///
+    /// a.insert(1, "a");
+    /// a.insert(2, "b");
+    ///
+    /// // Capacity remains the same until node is split or reallocated
+    /// assert_eq!(a.node_count(), 2);
+    /// ```
+    pub fn node_count(&self) -> usize {
+        self.set.node_count()
+    }
     /// Gets an iterator over the entries of the map, sorted by key.
     ///
     /// # Examples

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -408,6 +408,15 @@ impl<T: Ord + Clone + Send> BTreeSet<T> {
             .map(|node| node.value().lock().len())
             .sum()
     }
+    pub fn capacity(&self) -> usize {
+        self.index
+            .iter()
+            .map(|entry| {
+                let guard = entry.value().lock();
+                guard.capacity()
+            })
+            .sum()
+    }
 }
 
 impl<T> FromIterator<T> for BTreeSet<T>

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -417,6 +417,9 @@ impl<T: Ord + Clone + Send> BTreeSet<T> {
             })
             .sum()
     }
+    pub fn node_count(&self) -> usize {
+        self.index.len()
+    }
 }
 
 impl<T> FromIterator<T> for BTreeSet<T>

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -9,6 +9,8 @@ pub trait NodeLike<T: Ord> {
     #[allow(dead_code)]
     fn len(&self) -> usize;
     #[allow(dead_code)]
+    fn capacity(&self) -> usize;
+    #[allow(dead_code)]
     fn insert(&mut self, value: T) -> (bool, usize);
     #[allow(dead_code)]
     fn contains<Q: Ord + ?Sized>(&self, value: &Q) -> bool
@@ -133,6 +135,10 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     #[inline]
     fn len(&self) -> usize {
         self.len()
+    }
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.capacity()
     }
     #[inline]
     fn insert(&mut self, value: T) -> (bool, usize) {


### PR DESCRIPTION
capacity() method returns allocated elements of BtreeMap and BtreeMultiMap
node_count() method 

It's needed to calculate allocated memory 