### PR TITLE
Add inner `Node` customization

### DIFF
--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -141,7 +141,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::map::BTreeMap;
     ///
-    /// let mut map = BTreeMap::new();
+    /// let mut map = BTreeMap::<usize, &str>::new();
     ///
     /// // entries can now be inserted into the empty map
     /// map.insert(1, "a");
@@ -159,7 +159,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::map::BTreeMap;
     ///
-    /// let map: BTreeMap<i32, i32> = BTreeMap::with_maximum_node_size(128);
+    /// let map = BTreeMap::<i32, i32>::with_maximum_node_size(128);
     pub fn with_maximum_node_size(node_capacity: usize) -> Self {
         Self {
             set: BTreeSet::with_maximum_node_size(node_capacity),
@@ -185,7 +185,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::map::BTreeMap;
     ///
-    /// let mut map = BTreeMap::new();
+    /// let mut map = BTreeMap::<usize, &str>::new();
     /// map.insert(1, "a");
     /// assert_eq!(map.contains_key(&1), true);
     /// assert_eq!(map.contains_key(&2), false);
@@ -209,7 +209,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::map::BTreeMap;
     ///
-    /// let mut map = BTreeMap::new();
+    /// let mut map = BTreeMap::<usize, &str>::new();
     /// map.insert(1, "a");
     /// assert_eq!(map.get(&1).and_then(|e| Some(e.get().value)), Some("a"));
     /// assert_eq!(map.get(&2).and_then(|e| Some(e.get().value)), None);
@@ -236,7 +236,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::map::BTreeMap;
     ///
-    /// let mut map = BTreeMap::new();
+    /// let mut map = BTreeMap::<usize, &str>::new();
     /// assert_eq!(map.insert(37, "a"), None);
     /// assert_eq!(map.len() == 0, false);
     ///
@@ -272,7 +272,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::map::BTreeMap;
     ///
-    /// let map = BTreeMap::new();
+    /// let map = BTreeMap::<usize, &str>::new();
     /// map.insert(1, "a");
     /// assert_eq!(map.remove(&1), Some((1, "a")));
     /// assert_eq!(map.remove(&1), None);
@@ -282,11 +282,14 @@ where K: Send + Ord + Clone + 'static,
         Pair<K, V>: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        return self
+        self
             .set
             .remove(key)
-            .and_then(|pair| Some((pair.key, pair.value)));
+            .and_then(|pair| Some((pair.key, pair.value)))
     }
+    /// Removes a key from the map, returning the key and the value if the key
+    /// was previously in the map and [`ChangeEvent`]s describing changes caused
+    /// by this action.
     pub fn remove_cdc<Q>(&self, key: &Q) -> (Option<(K, V)>, Vec<ChangeEvent<Pair<K, V>>>)
     where
         Pair<K, V>: Borrow<Q> + Ord,
@@ -305,7 +308,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::map::BTreeMap;
     ///
-    /// let mut a = BTreeMap::new();
+    /// let mut a = BTreeMap::<usize, &str>::new();
     /// assert_eq!(a.len(), 0);
     /// a.insert(1, "a");
     /// assert_eq!(a.len(), 1);
@@ -326,7 +329,6 @@ where K: Send + Ord + Clone + 'static,
     /// use indexset::concurrent::map::BTreeMap;
     ///
     /// let mut a = BTreeMap::<usize, &str>::with_maximum_node_size(16);
-    /// assert_eq!(a.capacity(), 16);
     ///
     /// a.insert(1, "a");
     /// a.insert(2, "b");
@@ -348,13 +350,11 @@ where K: Send + Ord + Clone + 'static,
     /// use indexset::concurrent::map::BTreeMap;
     ///
     /// let mut a = BTreeMap::<usize, &str>::with_maximum_node_size(16);
-    /// assert_eq!(a.node_count(), 16);
     ///
     /// a.insert(1, "a");
     /// a.insert(2, "b");
     ///
-    /// // Capacity remains the same until node is split or reallocated
-    /// assert_eq!(a.node_count(), 2);
+    /// assert_eq!(a.node_count(), 1);
     /// ```
     pub fn node_count(&self) -> usize {
         self.set.node_count()
@@ -405,7 +405,7 @@ where K: Send + Ord + Clone + 'static,
     /// use indexset::concurrent::map::BTreeMap;
     /// use std::ops::Bound::Included;
     ///
-    /// let mut map = BTreeMap::<usize, &str>::new();
+    /// let mut map = BTreeMap::<i32, &str>::new();
     /// map.insert(3, "a");
     /// map.insert(5, "b");
     /// map.insert(8, "c");

--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -165,10 +165,13 @@ where K: Send + Ord + Clone + 'static,
             set: BTreeSet::with_maximum_node_size(node_capacity),
         }
     }
+    /// Adds full [`Node`] to this set. [`Node`] should be correct node with
+    /// values sorted.
     #[cfg(feature = "cdc")]
     pub fn attach_node(&self, node: Node) {
         self.set.attach_node(node)
     }
+    /// Returns iterator over this set's [`Node`]'s.
     #[cfg(feature = "cdc")]
     pub fn iter_nodes(&self) -> impl Iterator<Item=Arc<Mutex<Node>>> + '_ {
         self.set.index.iter().map(|e| e.value().clone())
@@ -252,6 +255,9 @@ where K: Send + Ord + Clone + 'static,
             .0
             .and_then(|pair| Some(pair.value))
     }
+    /// Inserts a key-value pair into the map and returns old value (if it was
+    /// already in set) with [`ChangeEvent`]'s that describes this insert
+    /// action.
     pub fn insert_cdc(&self, key: K, value: V) -> (Option<V>, Vec<ChangeEvent<Pair<K, V>>>) {
         let new_entry = Pair { key, value };
 
@@ -421,7 +427,7 @@ where K: Send + Ord + Clone + 'static,
         R: RangeBounds<Q>,
     {
         Range {
-            inner: super::set::BTreeSet::range(&self.set, range),
+            inner: BTreeSet::range(&self.set, range),
         }
     }
 }

--- a/src/concurrent/multimap.rs
+++ b/src/concurrent/multimap.rs
@@ -179,7 +179,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     ///
-    /// let mut map = BTreeMultiMap::new();
+    /// let mut map = BTreeMultiMap::<usize, &str>::new();
     ///
     /// // entries can now be inserted into the empty map
     /// map.insert(1, "a");
@@ -197,7 +197,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     ///
-    /// let map: BTreeMultiMap<i32, i32> = BTreeMultiMap::with_maximum_node_size(128);
+    /// let map = BTreeMultiMap::<i32, i32>::with_maximum_node_size(128);
     pub fn with_maximum_node_size(node_capacity: usize) -> Self {
         Self {
             set: BTreeSet::with_maximum_node_size(node_capacity),
@@ -223,7 +223,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     ///
-    /// let mut map = BTreeMultiMap::new();
+    /// let mut map = BTreeMultiMap::<usize, &str>::new();
     /// map.insert(1, "a");
     /// map.insert(1, "b");
     /// assert_eq!(map.contains_key(&1), true);
@@ -262,7 +262,7 @@ where K: Send + Ord + Clone + 'static,
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     /// use indexset::BTreeSet;
     ///
-    /// let mut map = BTreeMultiMap::new();
+    /// let mut map = BTreeMultiMap::<usize, &str>::new();
     /// 
     /// map.insert(1, "b");
     /// map.insert(1, "a");
@@ -292,7 +292,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     ///
-    /// let mut map = BTreeMultiMap::new();
+    /// let mut map = BTreeMultiMap::<usize, &str>::new();
     /// assert_eq!(map.insert(37, "a"), None);
     /// assert_eq!(map.len() == 0, false);
     ///
@@ -327,7 +327,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     ///
-    /// let map = BTreeMultiMap::new();
+    /// let map = BTreeMultiMap::<usize, &str>::new();
     /// map.insert(1, "b");
     /// map.insert(1, "a");
     /// 
@@ -367,7 +367,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     ///
-    /// let map = BTreeMultiMap::new();
+    /// let map = BTreeMultiMap::<usize, &str>::new();
     /// map.insert(1, "b");
     /// map.insert(1, "a");
     /// 
@@ -406,7 +406,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     ///
-    /// let mut a = BTreeMultiMap::new();
+    /// let mut a = BTreeMultiMap::<usize, &str>::new();
     /// assert_eq!(a.len(), 0);
     /// a.insert(1, "a");
     /// assert_eq!(a.len(), 1);
@@ -426,8 +426,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     ///
-    /// let mut a = BTreeMultiMap::with_maximum_node_size(8);
-    /// assert_eq!(a.capacity(), 8);
+    /// let mut a = BTreeMultiMap::<usize, &str>::with_maximum_node_size(8);
     ///
     /// a.insert(1, "a");
     /// a.insert(1, "b");
@@ -448,14 +447,12 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::map::BTreeMap;
     ///
-    /// let mut a = BTreeMap::with_maximum_node_size(16);
-    /// assert_eq!(a.node_count(), 16);
+    /// let mut a = BTreeMap::<usize, &str>::with_maximum_node_size(16);
     ///
     /// a.insert(1, "a");
     /// a.insert(2, "b");
     ///
-    /// // Capacity remains the same until node is split or reallocated
-    /// assert_eq!(a.node_count(), 2);
+    /// assert_eq!(a.node_count(), 1);
     /// ```
     pub fn node_count(&self) -> usize {
         self.set.node_count()
@@ -469,7 +466,7 @@ where K: Send + Ord + Clone + 'static,
     /// ```
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     ///
-    /// let mut map = BTreeMultiMap::new();
+    /// let mut map = BTreeMultiMap::<usize, &str>::new();
     /// map.insert(3, "c");
     /// map.insert(2, "b");
     /// map.insert(1, "a");
@@ -506,7 +503,7 @@ where K: Send + Ord + Clone + 'static,
     /// use indexset::concurrent::multimap::BTreeMultiMap;
     /// use std::ops::Bound::Included;
     ///
-    /// let mut map = BTreeMultiMap::new();
+    /// let mut map = BTreeMultiMap::<usize, &str>::new();
     /// map.insert(3, "a");
     /// map.insert(5, "b");
     /// map.insert(8, "c");

--- a/src/concurrent/operation.rs
+++ b/src/concurrent/operation.rs
@@ -17,7 +17,7 @@ pub enum Operation<T: Send + Ord, Node: NodeLike<T>> {
 
 impl<T, Node> Operation<T, Node>
 where T: Ord + Send + Clone + 'static,
-        Node: NodeLike<T> + Send + 'static,
+      Node: NodeLike<T> + Send + 'static,
 {
     pub fn commit(self, index: &SkipMap<T, Arc<Mutex<Node>>>) -> Result<(Option<T>, Vec<ChangeEvent<T>>), ()> {
         match self {

--- a/src/concurrent/operation.rs
+++ b/src/concurrent/operation.rs
@@ -6,19 +6,20 @@ use parking_lot::Mutex;
 use crate::cdc::change::ChangeEvent;
 use crate::core::node::NodeLike;
 
-pub type Node<T> = Arc<Mutex<Vec<T>>>;
+type OldVersion<Node> = Arc<Mutex<Node>>;
+type CurrentVersion<Node> = Arc<Mutex<Node>>;
 
-type OldVersion<T> = Node<T>;
-type CurrentVersion<T> = Node<T>;
-
-pub enum Operation<T: Send> {
-    Split(OldVersion<T>, T, T),
-    UpdateMax(CurrentVersion<T>, T),
-    MakeUnreachable(CurrentVersion<T>, T),
+pub enum Operation<T: Send + Ord, Node: NodeLike<T>> {
+    Split(OldVersion<Node>, T, T),
+    UpdateMax(CurrentVersion<Node>, T),
+    MakeUnreachable(CurrentVersion<Node>, T),
 }
 
-impl<T: Ord + Send + Clone + 'static> Operation<T> {
-    pub fn commit(self, index: &SkipMap<T, Node<T>>) -> Result<(Option<T>, Vec<ChangeEvent<T>>), ()> {
+impl<T, Node> Operation<T, Node>
+where T: Ord + Send + Clone + 'static,
+        Node: NodeLike<T> + Send + 'static,
+{
+    pub fn commit(self, index: &SkipMap<T, Arc<Mutex<Node>>>) -> Result<(Option<T>, Vec<ChangeEvent<T>>), ()> {
         match self {
             Operation::Split(old_node, old_max, value) => {
                 let mut guard = old_node.lock_arc();
@@ -39,7 +40,7 @@ impl<T: Ord + Send + Clone + 'static> Operation<T> {
 
                         let mut old_value: Option<T> = None;
                         let mut insert_attempted = false;
-                        if let Some(max) = guard.last().cloned() {
+                        if let Some(max) = guard.max().cloned() {
                             if max > value {
                                 let (inserted, idx) = NodeLike::insert(&mut *guard, value.clone());
                                 insert_attempted = true;
@@ -69,7 +70,7 @@ impl<T: Ord + Send + Clone + 'static> Operation<T> {
                             index.insert(max, old_node.clone());
                         }
 
-                        if let Some(mut max) = new_vec.last().cloned() {
+                        if let Some(mut max) = new_vec.max().cloned() {
                             if !insert_attempted {
                                 let (inserted, idx) = NodeLike::insert(&mut new_vec, value.clone());
                                 let old_max = max.clone();
@@ -112,7 +113,7 @@ impl<T: Ord + Send + Clone + 'static> Operation<T> {
             }
             Operation::UpdateMax(node, old_max) => {
                 let guard = node.lock_arc();
-                let new_max = guard.last().unwrap();
+                let new_max = guard.max().unwrap();
                 if let Some(entry) = index.get(&old_max) {
                     if Arc::ptr_eq(entry.value(), &node) {
                         let mut cdc = vec![];
@@ -142,7 +143,7 @@ impl<T: Ord + Send + Clone + 'static> Operation<T> {
             }
             Operation::MakeUnreachable(node, old_max) => {
                 let guard = node.lock_arc();
-                let new_max = guard.last();
+                let new_max = guard.max();
                 if let Some(entry) = index.get(&old_max) {
                     if Arc::ptr_eq(entry.value(), &node) {
                         return match new_max.cmp(&Some(&old_max)) {

--- a/src/concurrent/ref.rs
+++ b/src/concurrent/ref.rs
@@ -1,12 +1,15 @@
+use std::marker::PhantomData;
 use parking_lot::{ArcMutexGuard, RawMutex};
+use crate::core::node::NodeLike;
 
-pub struct Ref<T: Ord + Clone + Send> {
-    pub(super) node_guard: ArcMutexGuard<RawMutex, Vec<T>>,
+pub struct Ref<T: Ord + Clone + Send, Node: NodeLike<T> + Send> {
+    pub(super) node_guard: ArcMutexGuard<RawMutex, Node>,
     pub(super) position: usize,
+    pub(super) phantom_data: PhantomData<T>
 }
 
-impl<T: Ord + Clone + Send> Ref<T> {
+impl<T: Ord + Clone + Send, Node: NodeLike<T> + Send> Ref<T, Node> {
     pub fn get(&self) -> &T {
-        self.node_guard.get(self.position).unwrap()
+        self.node_guard.get_ith(self.position).unwrap()
     }
 }

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -159,7 +159,7 @@ where T: Ord + Clone + Send,
 
             let mut node_guard = target_node_entry.value().lock_arc();
             let mut operation = None;
-            if node_guard.len() < self.node_capacity {
+            if !node_guard.need_to_split() {
                 let old_max = node_guard.max().cloned();
                 let (inserted, idx) = NodeLike::insert(&mut *node_guard, value.clone());
                 if inserted {

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -40,7 +40,7 @@ use super::r#ref::Ref;
 ///
 /// // Type inference lets us omit an explicit type signature (which
 /// // would be `BTreeSet<&str>` in this example).
-/// let mut books = BTreeSet::new();
+/// let mut books = BTreeSet::<&str>::new();
 ///
 /// // Add some books.
 /// books.insert("A Dance With Dragons");
@@ -159,7 +159,7 @@ where T: Ord + Clone + Send,
 
             let mut node_guard = target_node_entry.value().lock_arc();
             let mut operation = None;
-            if node_guard.len() < self.node_capacity {
+            if !node_guard.need_to_split(self.node_capacity) {
                 let old_max = node_guard.max().cloned();
                 let (inserted, idx) = NodeLike::insert(&mut *node_guard, value.clone());
                 if inserted {
@@ -243,7 +243,7 @@ where T: Ord + Clone + Send,
     /// ```
     /// use indexset::concurrent::set::BTreeSet;
     ///
-    /// let mut set = BTreeSet::new();
+    /// let mut set = BTreeSet::<usize>::new();
     ///
     /// assert_eq!(set.insert(2), true);
     /// assert_eq!(set.insert(2), false);
@@ -332,7 +332,7 @@ where T: Ord + Clone + Send,
     /// ```
     /// use indexset::concurrent::set::BTreeSet;
     ///
-    /// let mut set = BTreeSet::new();
+    /// let mut set = BTreeSet::<usize>::new();
     ///
     /// set.insert(2);
     /// assert_eq!(set.remove(&2).is_some(), true);
@@ -876,7 +876,7 @@ where
     /// use indexset::concurrent::set::BTreeSet;
     /// use std::ops::Bound::Included;
     ///
-    /// let mut set = BTreeSet::new();
+    /// let mut set = BTreeSet::<usize>::new();
     /// set.insert(3);
     /// set.insert(5);
     /// set.insert(8);

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -1097,13 +1097,13 @@ mod tests {
     #[test]
     fn test_insert_st() {
         let set = Arc::new(BTreeSet::<i32>::new());
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let n = 2048 * 100;
         let range = 0..n;
         let mut inserted_values = HashSet::new();
         for _ in range {
-            let value = rng.gen_range(0..n);
+            let value = rng.random_range(0..n);
             if inserted_values.insert(value) {
                 set.insert(value);
             }

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -1045,11 +1045,11 @@ mod tests {
 
         let test_data: Vec<Vec<(i32, i32)>> = (0..num_threads)
             .map(|_| {
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 (0..operations_per_thread)
                     .map(|_| {
-                        let value = rng.gen_range(0..100000);
-                        let operation = rng.gen_range(0..2);
+                        let value = rng.random_range(0..100000);
+                        let operation = rng.random_range(0..2);
                         (operation, value)
                     })
                     .collect()

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -159,7 +159,7 @@ where T: Ord + Clone + Send,
 
             let mut node_guard = target_node_entry.value().lock_arc();
             let mut operation = None;
-            if !node_guard.need_to_split() {
+            if node_guard.len() < self.node_capacity {
                 let old_max = node_guard.max().cloned();
                 let (inserted, idx) = NodeLike::insert(&mut *node_guard, value.clone());
                 if inserted {

--- a/src/core/multipair.rs
+++ b/src/core/multipair.rs
@@ -9,7 +9,7 @@ use fastrand;
 use crate::core::pair::Pair;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Default, Clone, Hash)]
 pub struct MultiPair<K, V> {
     pub key: K,
     pub value: V,

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -131,6 +131,7 @@ where
 }
 
 impl<T: Ord> NodeLike<T> for Vec<T> {
+    #[inline]
     fn with_capacity(capacity: usize) -> Self {
         Vec::with_capacity(capacity)
     }
@@ -215,6 +216,7 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
         self.last()
     }
 
+    #[inline]
     fn min(&self) -> Option<&T> {
         self.first()
     }

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -1,7 +1,10 @@
 use core::borrow::Borrow;
 use core::cmp::Ordering;
+use std::ops::Deref;
 
 pub trait NodeLike<T: Ord> {
+    #[allow(dead_code)]
+    fn with_capacity(capacity: usize) -> Self;
     #[allow(dead_code)]
     fn get_ith(&self, index: usize) -> Option<&T>;
     #[allow(dead_code)]
@@ -32,6 +35,10 @@ pub trait NodeLike<T: Ord> {
     fn replace(&mut self, idx: usize, value: T) -> Option<T>;
     #[allow(dead_code)]
     fn max(&self) -> Option<&T>;
+    #[allow(dead_code)]
+    fn min(&self) -> Option<&T>;
+    #[allow(dead_code)]
+    fn iter<'a>(&'a self) -> std::slice::Iter<'a, T> where T: 'a;
 }
 
 #[inline]
@@ -124,6 +131,9 @@ where
 }
 
 impl<T: Ord> NodeLike<T> for Vec<T> {
+    fn with_capacity(capacity: usize) -> Self {
+        Vec::with_capacity(capacity)
+    }
     #[inline]
     fn get_ith(&self, index: usize) -> Option<&T> {
         self.get(index)
@@ -203,6 +213,17 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     #[inline]
     fn max(&self) -> Option<&T> {
         self.last()
+    }
+
+    fn min(&self) -> Option<&T> {
+        self.first()
+    }
+
+    #[inline]
+    fn iter<'a>(&'a self) -> std::slice::Iter<'a, T>
+    where T: 'a
+    {
+        self.deref().iter()
     }
 }
 

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -10,7 +10,7 @@ pub trait NodeLike<T: Ord> {
     #[allow(dead_code)]
     fn halve(&mut self) -> Self;
     #[allow(dead_code)]
-    fn need_to_split(&self) -> bool;
+    fn need_to_split(&self, border: usize) -> bool;
     #[allow(dead_code)]
     fn len(&self) -> usize;
     #[allow(dead_code)]
@@ -145,12 +145,10 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     fn halve(&mut self) -> Self {
         self.split_off(self.capacity() / 2)
     }
-
     #[inline]
-    fn need_to_split(&self) -> bool {
-        self.len() >= self.capacity()
+    fn need_to_split(&self, border: usize) -> bool {
+        self.len() >= border
     }
-
     #[inline]
     fn len(&self) -> usize {
         self.len()
@@ -223,12 +221,10 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     fn max(&self) -> Option<&T> {
         self.last()
     }
-
     #[inline]
     fn min(&self) -> Option<&T> {
         self.first()
     }
-
     #[inline]
     fn iter<'a>(&'a self) -> std::slice::Iter<'a, T>
     where T: 'a

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -10,6 +10,8 @@ pub trait NodeLike<T: Ord> {
     #[allow(dead_code)]
     fn halve(&mut self) -> Self;
     #[allow(dead_code)]
+    fn need_to_split(&self) -> bool;
+    #[allow(dead_code)]
     fn len(&self) -> usize;
     #[allow(dead_code)]
     fn capacity(&self) -> usize;
@@ -143,6 +145,12 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     fn halve(&mut self) -> Self {
         self.split_off(self.capacity() / 2)
     }
+
+    #[inline]
+    fn need_to_split(&self) -> bool {
+        self.len() >= self.capacity()
+    }
+
     #[inline]
     fn len(&self) -> usize {
         self.len()

--- a/src/core/pair.rs
+++ b/src/core/pair.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Default, Clone, Hash)]
 pub struct Pair<K, V>
 {
     pub key: K,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4298,7 +4298,7 @@ mod tests {
         let mut btree = BTreeSet::new();
         let n = 100_000;
         for _ in 0..n {
-            let value: u64 = rng.gen_range(1..10000);
+            let value: u64 = rng.random_range(1..10000);
             let lower: u64 = 1650;
             let len_before = btree.len();
             // Use max to increase the number of duplicates


### PR DESCRIPTION
This PR makes inner set's `Node` generic. `Node` should implement `NodeLike` trait to be used inside. 

Also some little docs corrections.