### PR TITLE
Add value ref pass into `need_to_split`

### DIFF
--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -181,7 +181,7 @@ where
             let mut operation = None;
             #[cfg(feature = "cdc")]
             let mut operation_id = 0.into();
-            if !node_guard.need_to_split(self.node_capacity) {
+            if !node_guard.need_to_split(self.node_capacity, &value) {
                 let old_max = node_guard.max().cloned();
                 let (inserted, idx) = NodeLike::insert(&mut *node_guard, value.clone());
                 if inserted {

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -12,6 +12,8 @@ pub trait NodeLike<T: Ord> {
     #[allow(dead_code)]
     fn need_to_split(&self, border: usize) -> bool;
     #[allow(dead_code)]
+    fn need_to_split_with_value_check(&self, border: usize, value: &T) -> bool;
+    #[allow(dead_code)]
     fn len(&self) -> usize;
     #[allow(dead_code)]
     fn capacity(&self) -> usize;
@@ -149,6 +151,11 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     fn need_to_split(&self, border: usize) -> bool {
         self.len() >= border
     }
+    #[inline]
+    fn need_to_split_with_value_check(&self, border: usize, _: &T) -> bool {
+        self.len() >= border
+    }
+
     #[inline]
     fn len(&self) -> usize {
         self.len()

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -10,9 +10,7 @@ pub trait NodeLike<T: Ord> {
     #[allow(dead_code)]
     fn halve(&mut self) -> Self;
     #[allow(dead_code)]
-    fn need_to_split(&self, border: usize) -> bool;
-    #[allow(dead_code)]
-    fn need_to_split_with_value_check(&self, border: usize, value: &T) -> bool;
+    fn need_to_split(&self, border: usize, value: &T) -> bool;
     #[allow(dead_code)]
     fn len(&self) -> usize;
     #[allow(dead_code)]
@@ -148,14 +146,9 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
         self.split_off(self.capacity() / 2)
     }
     #[inline]
-    fn need_to_split(&self, border: usize) -> bool {
+    fn need_to_split(&self, border: usize, _: &T) -> bool {
         self.len() >= border
     }
-    #[inline]
-    fn need_to_split_with_value_check(&self, border: usize, _: &T) -> bool {
-        self.len() >= border
-    }
-
     #[inline]
     fn len(&self) -> usize {
         self.len()


### PR DESCRIPTION
This is useful, because need to split now have ability to check it's _current_ inner state at check moment, so node is already full at split moment.

In my use case I use custom `Node` implementation which uses other metric than length, it uses sum of inner value sizes (like for `String` sum of value lengths). In this case situation with overflow is possible, as on `need_to_split` we check _current_ `Node` state.

This update allows to check `Node`'s state at one step forward, like value was added (value is passed to get it's params)