### PR TITLE
Add proper monotonicity logic for CDC events

### DIFF
--- a/src/cdc/change.rs
+++ b/src/cdc/change.rs
@@ -1,7 +1,8 @@
 #[cfg(feature = "multimap")]
-use crate::core::multipair::MultiPair;
-
-use crate::core::pair::Pair;
+use {
+    crate::core::multipair::MultiPair,
+    crate::core::pair::Pair,
+};
 
 /// Unique event identifier.
 ///
@@ -84,6 +85,64 @@ impl<T> ChangeEvent<T> {
             ChangeEvent::CreateNode { event_id, .. } => *event_id,
             ChangeEvent::RemoveNode { event_id, .. } => *event_id,
             ChangeEvent::SplitNode { event_id, .. } => *event_id,
+        }
+    }
+}
+
+/// A [`ChangeEvent`] that has not yet been assigned an event [`Id`].
+///
+/// This type is used to defer event [`Id`] allocation until after an operation
+/// successfully commits, ensuring no gaps in event [`Id`]a.
+#[derive(Debug, Clone)]
+pub enum ChangeEventUnassigned<T> {
+    /// Unassigned [`ChangeEvent::InsertAt`].
+    InsertAt {
+        max_value: T,
+        value: T,
+        index: usize,
+    },
+    /// Unassigned [`ChangeEvent::RemoveAt`].
+    RemoveAt {
+        max_value: T,
+        value: T,
+        index: usize,
+    },
+    /// Unassigned [`ChangeEvent::CreateNode`].
+    CreateNode {
+        max_value: T,
+    },
+    /// Unassigned [`ChangeEvent::RemoveNode`].
+    RemoveNode {
+        max_value: T,
+    },
+    /// Unassigned [`ChangeEvent::SplitNode`].
+    SplitNode {
+        max_value: T,
+        split_index: usize,
+    },
+}
+
+impl<T> ChangeEventUnassigned<T> {
+    /// Assign an event [`Id`] to this unassigned event, converting it to a [`ChangeEvent`].
+    pub fn assign_id(self, event_id: Id) -> ChangeEvent<T> {
+        match self {
+            Self::InsertAt { max_value, value, index } => ChangeEvent::InsertAt {
+                event_id,
+                max_value,
+                value,
+                index,
+            },
+            Self::RemoveAt { max_value, value, index } => ChangeEvent::RemoveAt {
+                event_id,
+                max_value,
+                value,
+                index,
+            },
+            Self::CreateNode { max_value } => ChangeEvent::CreateNode { event_id, max_value },
+            Self::RemoveNode { max_value } => ChangeEvent::RemoveNode { event_id, max_value },
+            Self::SplitNode { max_value, split_index } => {
+                ChangeEvent::SplitNode { event_id, max_value, split_index }
+            }
         }
     }
 }

--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -453,6 +453,7 @@ mod tests {
     use std::fmt::Debug;
     use std::sync::{Arc, Mutex};
     use std::thread;
+    use crate::core::constants::DEFAULT_INNER_SIZE;
 
     #[test]
     fn test_range_edge_cast() {
@@ -739,5 +740,182 @@ mod tests {
             .map(|e| (e.key().clone().key, e.value().lock_arc().clone()))
             .collect::<_>();
         assert_eq!(mock_state.nodes, expected_state);
+    }
+    
+    #[cfg(feature = "cdc")]
+    #[test]
+    fn test_cdc_event_ids_sequential_no_gaps() {
+        let map = BTreeMap::<usize, String>::new();
+        let mut all_events = Vec::new();
+        
+        for i in 0..100 {
+            let (_, events) = map.insert_cdc(i, format!("val{}", i));
+            all_events.extend(events);
+        }
+        all_events.sort_by_key(|e| e.id());
+
+        // Verify IDs are consecutive with no gaps
+        assert!(!all_events.is_empty(), "Should have at least one event");
+        for i in 1..all_events.len() {
+            let prev_id = all_events[i - 1].id().inner();
+            let curr_id = all_events[i].id().inner();
+            assert_eq!(
+                curr_id,
+                prev_id + 1,
+                "Event IDs should be consecutive: {} followed by {}, but got gap",
+                prev_id,
+                curr_id
+            );
+        }
+    }
+    
+    #[cfg(feature = "cdc")]
+    #[test]
+    fn test_cdc_remove_monotonicity() {
+        let map = BTreeMap::<usize, String>::new();
+        let mut all_events = Vec::new();
+        
+        for i in 0..50 {
+            let (_, events) = map.insert_cdc(i, format!("val{}", i));
+            all_events.extend(events);
+        }
+        
+        for i in 0..25 {
+            let (_, events) = map.remove_cdc(&i);
+            all_events.extend(events);
+        }
+        
+        all_events.sort_by_key(|e| e.id());
+
+        // Verify IDs are consecutive with no gaps
+        assert!(!all_events.is_empty(), "Should have at least one event");
+        for i in 1..all_events.len() {
+            let prev_id = all_events[i - 1].id().inner();
+            let curr_id = all_events[i].id().inner();
+            assert_eq!(
+                curr_id,
+                prev_id + 1,
+                "Event IDs should be consecutive across inserts and removes"
+            );
+        }
+    }
+    
+    #[cfg(feature = "cdc")]
+    #[test]
+    fn test_cdc_split_no_gaps() {
+        let map = BTreeMap::<usize, String>::new();
+        let mut all_events = Vec::new();
+        
+        let n = DEFAULT_INNER_SIZE + 200;
+        for i in 0..n {
+            let (_, events) = map.insert_cdc(i, format!("val{}", i));
+            all_events.extend(events);
+        }
+        
+        all_events.sort_by_key(|e| e.id());
+        
+        assert!(!all_events.is_empty(), "Should have at least one event");
+        for i in 1..all_events.len() {
+            let prev_id = all_events[i - 1].id().inner();
+            let curr_id = all_events[i].id().inner();
+            assert_eq!(
+                curr_id,
+                prev_id + 1,
+                "Event IDs should be consecutive even during splits"
+            );
+        }
+
+        // Verify splits actually occurred
+        let split_events: Vec<_> = all_events
+            .iter()
+            .filter(|e| matches!(e, ChangeEvent::SplitNode { .. }))
+            .collect();
+        assert!(
+            !split_events.is_empty(),
+            "Should have at least one split event"
+        );
+    }
+    
+    #[cfg(feature = "cdc")]
+    #[test]
+    fn test_concurrent_cdc_no_gaps() {
+        let map = Arc::new(BTreeMap::<usize, String>::new());
+        let num_threads = 16;
+        let operations_per_thread = 500;
+        let mut handles = vec![];
+
+        for thread_idx in 0..num_threads {
+            let map_clone = Arc::clone(&map);
+
+            let handle = thread::spawn(move || {
+                let mut events = Vec::new();
+                let base = thread_idx * 10000;
+                for i in 0..operations_per_thread {
+                    let value = base + i;
+                    let (_, evs) = map_clone.insert_cdc(value, format!("val{}", value));
+                    events.extend(evs);
+                }
+                events
+            });
+            handles.push(handle);
+        }
+        
+        let mut final_events = Vec::new();
+        for handle in handles {
+            let thread_events = handle.join().unwrap();
+            final_events.extend(thread_events);
+        }
+        
+        final_events.sort_by_key(|e| e.id());
+
+        // Verify no gaps in event IDs
+        assert!(!final_events.is_empty(), "Should have at least one event");
+        for i in 1..final_events.len() {
+            let prev_id = final_events[i - 1].id().inner();
+            let curr_id = final_events[i].id().inner();
+            assert_eq!(
+                curr_id,
+                prev_id + 1,
+                "Concurrent event IDs should be consecutive with no gaps: {} -> {}",
+                prev_id,
+                curr_id
+            );
+        }
+    }
+    
+    #[cfg(feature = "cdc")]
+    #[test]
+    fn test_cdc_mixed_operations() {
+        let map = BTreeMap::<usize, String>::new();
+        let mut all_events = Vec::new();
+        
+        for i in 0..100 {
+            let (_, events) = map.insert_cdc(i, format!("val{}", i));
+            all_events.extend(events);
+        }
+        
+        for i in 0..50 {
+            let (_, events) = map.remove_cdc(&i);
+            all_events.extend(events);
+        }
+        
+        for i in 100..125 {
+            let (_, events) = map.insert_cdc(i, format!("val{}", i));
+            all_events.extend(events);
+        }
+        
+        all_events.sort_by_key(|e| e.id());
+
+        // Verify IDs are consecutive with no gaps
+        assert!(!all_events.is_empty(), "Should have at least one event");
+        for i in 1..all_events.len() {
+            let prev_id = all_events[i - 1].id().inner();
+            let curr_id = all_events[i].id().inner();
+            assert_eq!(
+                curr_id,
+                prev_id + 1,
+                "Mixed operation event IDs should be consecutive"
+            );
+        }
     }
 }

--- a/src/concurrent/operation.rs
+++ b/src/concurrent/operation.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 use crossbeam_skiplist::SkipMap;
 use parking_lot::Mutex;
 
-use crate::cdc::change::ChangeEvent;
-#[cfg(feature = "cdc")]
-use crate::cdc::change::Id;
+use crate::cdc::change::ChangeEventUnassigned;
 use crate::core::node::NodeLike;
 
 type OldVersion<Node> = Arc<Mutex<Node>>;
@@ -26,8 +24,7 @@ where
     pub fn commit(
         self,
         index: &SkipMap<T, Arc<Mutex<Node>>>,
-        #[cfg(feature = "cdc")] event_id: Id,
-    ) -> Result<(Option<T>, Vec<ChangeEvent<T>>), ()> {
+    ) -> Result<(Option<T>, Vec<ChangeEventUnassigned<T>>), ()> {
         match self {
             Operation::Split(old_node, old_max, value) => {
                 let mut guard = old_node.lock_arc();
@@ -44,8 +41,7 @@ where
 
                         #[cfg(feature = "cdc")]
                         {
-                            let node_split = ChangeEvent::SplitNode {
-                                event_id,
+                            let node_split = ChangeEventUnassigned::SplitNode {
                                 max_value,
                                 split_index: guard.len(),
                             };
@@ -62,8 +58,7 @@ where
                                     old_value = NodeLike::replace(&mut *guard, idx, value.clone());
                                     #[cfg(feature = "cdc")]
                                     {
-                                        let value_insertion = ChangeEvent::RemoveAt {
-                                            event_id,
+                                        let value_insertion = ChangeEventUnassigned::RemoveAt {
                                             max_value: max.clone(),
                                             index: idx,
                                             value: old_value.clone().unwrap(),
@@ -73,8 +68,7 @@ where
                                 }
                                 #[cfg(feature = "cdc")]
                                 {
-                                    let value_insertion = ChangeEvent::InsertAt {
-                                        event_id,
+                                    let value_insertion = ChangeEventUnassigned::InsertAt {
                                         max_value: max.clone(),
                                         index: idx,
                                         value: value.clone(),
@@ -98,8 +92,7 @@ where
                                     old_value = NodeLike::replace(&mut new_vec, idx, value.clone());
                                     #[cfg(feature = "cdc")]
                                     {
-                                        let value_insertion = ChangeEvent::RemoveAt {
-                                            event_id,
+                                        let value_insertion = ChangeEventUnassigned::RemoveAt {
                                             max_value: old_max.clone(),
                                             index: idx,
                                             value: old_value.clone().unwrap(),
@@ -109,8 +102,7 @@ where
                                 }
                                 #[cfg(feature = "cdc")]
                                 {
-                                    let value_insertion = ChangeEvent::InsertAt {
-                                        event_id,
+                                    let value_insertion = ChangeEventUnassigned::InsertAt {
                                         max_value: old_max.clone(),
                                         index: idx,
                                         value: value.clone(),
@@ -169,8 +161,7 @@ where
 
                                 #[cfg(feature = "cdc")]
                                 {
-                                    let node_removal = ChangeEvent::RemoveNode {
-                                        event_id,
+                                    let node_removal = ChangeEventUnassigned::RemoveNode {
                                         max_value: old_max.clone(),
                                     };
                                     cdc.push(node_removal);

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -159,7 +159,7 @@ where
                                 let node_insertion = ChangeEvent::CreateNode {
                                     // is correct as index is locked and current thread is the only that can
                                     // fetch event_id.
-                                    event_id: self.event_id.fetch_add(1, Ordering::Relaxed).into(),
+                                    event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
                                     max_value: value.clone(),
                                 };
                                 cdc.push(node_insertion);
@@ -179,8 +179,6 @@ where
 
             #[allow(unused_assignments)]
             let mut operation = None;
-            #[cfg(feature = "cdc")]
-            let mut operation_id = 0.into();
             if !node_guard.need_to_split(self.node_capacity, &value) {
                 let old_max = node_guard.max().cloned();
                 let (inserted, idx) = NodeLike::insert(&mut *node_guard, value.clone());
@@ -190,7 +188,7 @@ where
                         let node_element_insertion = ChangeEvent::InsertAt {
                             // is correct as node is locked and current thread is the only that can
                             // fetch event_id, so events for this node will have monotonic id's.
-                            event_id: self.event_id.fetch_add(1, Ordering::Relaxed).into(),
+                            event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
                             max_value: old_max.clone().unwrap_or(value.clone()),
                             value: value.clone(),
                             index: idx,
@@ -219,10 +217,6 @@ where
                     target_node_entry.key().clone(),
                     value.clone(),
                 ));
-                #[cfg(feature = "cdc")]
-                {
-                    operation_id = self.event_id.fetch_add(1, Ordering::Relaxed).into();
-                }
             }
 
             drop(node_guard);
@@ -233,24 +227,30 @@ where
             let op = operation.unwrap();
             match &op {
                 Operation::Split(_, _, _) => {
-                    if let Ok((value, value_cdc)) = op.commit(
-                        &self.index,
+                    if let Ok((value, value_cdc)) = op.commit(&self.index) {
                         #[cfg(feature = "cdc")]
-                        operation_id,
-                    ) {
-                        cdc.extend(value_cdc);
+                        {
+                            for unassigned_event in value_cdc {
+                                let event_id =
+                                    self.event_id.fetch_add(1, Ordering::AcqRel).into();
+                                cdc.push(unassigned_event.assign_id(event_id));
+                            }
+                        }
                         return Ok((value, cdc));
                     } else {
                         continue;
                     }
                 }
                 Operation::UpdateMax(_, _) => {
-                    return if let Ok((value, value_cdc)) = op.commit(
-                        &self.index,
+                    return if let Ok((value, value_cdc)) = op.commit(&self.index) {
                         #[cfg(feature = "cdc")]
-                        operation_id,
-                    ) {
-                        cdc.extend(value_cdc);
+                        {
+                            for unassigned_event in value_cdc {
+                                let event_id =
+                                    self.event_id.fetch_add(1, Ordering::AcqRel).into();
+                                cdc.push(unassigned_event.assign_id(event_id));
+                            }
+                        }
                         Ok((value, cdc))
                     } else {
                         Ok((None, cdc))
@@ -271,12 +271,12 @@ where
                         let node_removal = ChangeEvent::RemoveNode {
                             // is correct as node is locked and current thread is the only that can
                             // fetch event_id, so events for this node will have monotonic id's.
-                            event_id: self.event_id.fetch_add(1, Ordering::Relaxed).into(),
+                            event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
                             max_value: max.clone(),
                         };
                         let node_insertion = ChangeEvent::CreateNode {
                             // same as for previous.
-                            event_id: self.event_id.fetch_add(1, Ordering::Relaxed).into(),
+                            event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
                             max_value: value.clone(),
                         };
                         cdc.push(node_removal);
@@ -290,14 +290,14 @@ where
                         let node_element_removal = ChangeEvent::RemoveAt {
                             // is correct as node is locked and current thread is the only that can
                             // fetch event_id, so events for this node will have monotonic id's.
-                            event_id: self.event_id.fetch_add(1, Ordering::Relaxed).into(),
+                            event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
                             max_value: max.clone(),
                             value: value.clone(),
                             index: idx,
                         };
                         let node_element_insertion = ChangeEvent::InsertAt {
                             // same as for previous.
-                            event_id: self.event_id.fetch_add(1, Ordering::Relaxed).into(),
+                            event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
                             max_value: new_max.expect("length was checked so should be ok").clone(),
                             value: value.clone(),
                             index: idx,
@@ -308,14 +308,14 @@ where
                         let node_element_removal = ChangeEvent::RemoveAt {
                             // is correct as node is locked and current thread is the only that can
                             // fetch event_id, so events for this node will have monotonic id's.
-                            event_id: self.event_id.fetch_add(1, Ordering::Relaxed).into(),
+                            event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
                             max_value: max.clone(),
                             value: value.clone(),
                             index: idx,
                         };
                         let node_element_insertion = ChangeEvent::InsertAt {
                             // same as for previous.
-                            event_id: self.event_id.fetch_add(1, Ordering::Relaxed).into(),
+                            event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
                             max_value: max.clone(),
                             value: value.clone(),
                             index: idx,
@@ -366,7 +366,7 @@ where
             let mut cdc = vec![];
             let _global_guard = self.index_lock.read();
             if let Some(target_node_entry) =
-                self.index.lower_bound(std::ops::Bound::Included(&value))
+                self.index.lower_bound(Bound::Included(&value))
             {
                 let mut node_guard = target_node_entry.value().lock_arc();
                 let old_max = node_guard.max().cloned();
@@ -382,7 +382,7 @@ where
                         let node_element_removal = ChangeEvent::RemoveAt {
                             // is correct as node is locked and current thread is the only that can
                             // fetch event_id, so events for this node will have monotonic id's.
-                            event_id: self.event_id.fetch_add(1, Ordering::Relaxed).into(),
+                            event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
                             max_value: old_max
                                 .clone()
                                 .expect("Max value should exist as Node is not empty"),
@@ -407,20 +407,19 @@ where
                     ))
                 };
 
-                #[cfg(feature = "cdc")]
-                let operation_id = self.event_id.fetch_add(1, Ordering::Relaxed).into();
-
                 drop(node_guard);
                 drop(_global_guard);
 
                 let _global_guard = self.index_lock.write();
 
-                return if let Ok((_, value_cdc)) = operation.unwrap().commit(
-                    &self.index,
+                return if let Ok((_, value_cdc)) = operation.unwrap().commit(&self.index) {
                     #[cfg(feature = "cdc")]
-                    operation_id,
-                ) {
-                    cdc.extend(value_cdc);
+                    {
+                        for unassigned_event in value_cdc {
+                            let event_id = self.event_id.fetch_add(1, Ordering::AcqRel).into();
+                            cdc.push(unassigned_event.assign_id(event_id));
+                        }
+                    }
                     (Some(deleted), cdc)
                 } else {
                     (Some(deleted), cdc)


### PR DESCRIPTION
This PR adds `ChangeEventUnassigned` utility structure for `Operation`s logic to assign event `Id`s for them after `Operation` completion. It allows to have correct monotonous flow of `Id`s without any gaps in them. 

Also adds some tests for this logic coverage.