### PR TITLE
Add `.rustfmt.toml` and run `cargo fmt`

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2024"
+max_width = 120

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -111,7 +111,8 @@ fn bench_btreeset_with_ratio(c: &mut Criterion, write_ratio: f64) {
 
     group.bench_function(BenchmarkId::new("ConcurrentBTreeSet", write_ratio), |b| {
         b.iter(|| {
-            let set: Arc<indexset::concurrent::set::BTreeSet<usize>> = Arc::new(indexset::concurrent::set::BTreeSet::new());
+            let set: Arc<indexset::concurrent::set::BTreeSet<usize>> =
+                Arc::new(indexset::concurrent::set::BTreeSet::new());
             let mut handles = vec![];
 
             for thread_ops in operations.iter() {

--- a/src/cdc/change.rs
+++ b/src/cdc/change.rs
@@ -88,7 +88,6 @@ impl<T> ChangeEvent<T> {
     }
 }
 
-
 #[cfg(feature = "multimap")]
 impl<K: Ord, V: PartialEq> From<ChangeEvent<MultiPair<K, V>>> for ChangeEvent<Pair<K, V>> {
     fn from(ev: ChangeEvent<MultiPair<K, V>>) -> Self {

--- a/src/concurrent.rs
+++ b/src/concurrent.rs
@@ -1,7 +1,7 @@
 pub mod map;
-pub mod set;
-pub(crate) mod r#ref;
 pub(crate) mod operation;
+pub(crate) mod r#ref;
+pub mod set;
 
 #[cfg(feature = "multimap")]
 pub mod multimap;

--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -253,10 +253,7 @@ where
     pub fn insert(&self, key: K, value: V) -> Option<V> {
         let new_entry = Pair { key, value };
 
-        self.set
-            .put_cdc(new_entry)
-            .0
-            .and_then(|pair| Some(pair.value))
+        self.set.put_cdc(new_entry).0.and_then(|pair| Some(pair.value))
     }
     pub fn checked_insert(&self, key: K, value: V) -> Option<()> {
         let new_entry = Pair { key, value };
@@ -299,9 +296,7 @@ where
         Pair<K, V>: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        self.set
-            .remove(key)
-            .and_then(|pair| Some((pair.key, pair.value)))
+        self.set.remove(key).and_then(|pair| Some((pair.key, pair.value)))
     }
     /// Removes a key from the map, returning the key and the value if the key
     /// was previously in the map and [`ChangeEvent`]s describing changes caused
@@ -397,9 +392,7 @@ where
     /// assert_eq!((*first_key, *first_value), (1, "a"));
     /// ```
     pub fn iter(&self) -> Iter<'_, K, V, Node> {
-        Iter {
-            inner: self.set.iter(),
-        }
+        Iter { inner: self.set.iter() }
     }
     /// Constructs a double-ended iterator over a sub-range of elements in the map.
     /// The simplest way is to use the range syntax `min..max`, thus `range(min..max)` will
@@ -491,17 +484,11 @@ mod tests {
     impl<K: Debug + Ord + Clone, V: Debug + Clone + PartialEq> PersistedBTreeMap<K, V> {
         fn persist(&mut self, event: &ChangeEvent<Pair<K, V>>) {
             match event {
-                ChangeEvent::CreateNode {
-                    max_value,
-                    event_id: _,
-                } => {
+                ChangeEvent::CreateNode { max_value, event_id: _ } => {
                     let node = vec![max_value.clone()];
                     self.nodes.insert(max_value.key.clone(), node);
                 }
-                ChangeEvent::RemoveNode {
-                    max_value,
-                    event_id: _,
-                } => {
+                ChangeEvent::RemoveNode { max_value, event_id: _ } => {
                     self.nodes.remove(&max_value.key);
                 }
                 ChangeEvent::InsertAt {

--- a/src/concurrent/multimap.rs
+++ b/src/concurrent/multimap.rs
@@ -319,10 +319,7 @@ where
     pub fn insert(&self, key: K, value: V) -> Option<V> {
         let new_entry = MultiPair::new(key, value);
 
-        self.set
-            .put_cdc(new_entry)
-            .0
-            .and_then(|pair| Some(pair.value))
+        self.set.put_cdc(new_entry).0.and_then(|pair| Some(pair.value))
     }
     /// Inserts a key-value pair into the map and returns old value (if it was
     /// already in set) with [`ChangeEvent`]'s that describes this insert
@@ -364,9 +361,7 @@ where
         MultiPair<K, V>: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        self.set
-            .remove(key)
-            .and_then(|pair| Some((pair.key, pair.value)))
+        self.set.remove(key).and_then(|pair| Some((pair.key, pair.value)))
     }
     /// Removes some key from the map that matches the given key, returning the
     /// key and the value if the key was previously in the map with
@@ -419,11 +414,7 @@ where
     /// value if the key was previously in the map with [`ChangeEvent`]'s
     /// describing this `remove_some` action.
     #[cfg(feature = "cdc")]
-    pub fn remove_cdc(
-        &self,
-        key: &K,
-        value: &V,
-    ) -> (Option<(K, V)>, Vec<ChangeEvent<MultiPair<K, V>>>) {
+    pub fn remove_cdc(&self, key: &K, value: &V) -> (Option<(K, V)>, Vec<ChangeEvent<MultiPair<K, V>>>) {
         let discriminant_to_remove = self.raw_get(&key).find(|pair| pair.2 == value);
         if let Some(discriminant_to_remove) = discriminant_to_remove {
             let pair_to_remove = MultiPair {
@@ -520,9 +511,7 @@ where
     /// assert_eq!((*first_key, *first_value), (1, "a"));
     /// ```
     pub fn iter(&self) -> Iter<'_, K, V, Node> {
-        Iter {
-            inner: self.set.iter(),
-        }
+        Iter { inner: self.set.iter() }
     }
     /// Constructs a double-ended iterator over a sub-range of elements in the map.
     /// The simplest way is to use the range syntax `min..max`, thus `range(min..max)` will
@@ -559,22 +548,14 @@ where
     {
         let start_bound = range.start_bound();
         let adjusted_start_bound = match start_bound {
-            std::ops::Bound::Included(start) => {
-                std::ops::Bound::Included(MultiPair::with_infimum(start.clone()))
-            }
-            std::ops::Bound::Excluded(start) => {
-                std::ops::Bound::Excluded(MultiPair::with_supremum(start.clone()))
-            }
+            std::ops::Bound::Included(start) => std::ops::Bound::Included(MultiPair::with_infimum(start.clone())),
+            std::ops::Bound::Excluded(start) => std::ops::Bound::Excluded(MultiPair::with_supremum(start.clone())),
             _ => std::ops::Bound::Unbounded,
         };
         let end_bound = range.end_bound();
         let adjusted_end_bound = match end_bound {
-            std::ops::Bound::Included(end) => {
-                std::ops::Bound::Included(MultiPair::with_supremum(end.clone()))
-            }
-            std::ops::Bound::Excluded(end) => {
-                std::ops::Bound::Excluded(MultiPair::with_infimum(end.clone()))
-            }
+            std::ops::Bound::Included(end) => std::ops::Bound::Included(MultiPair::with_supremum(end.clone())),
+            std::ops::Bound::Excluded(end) => std::ops::Bound::Excluded(MultiPair::with_infimum(end.clone())),
             _ => std::ops::Bound::Unbounded,
         };
 
@@ -651,9 +632,7 @@ mod tests {
         let mid_range = map.range(2..3).collect::<BTreeSet<_>>();
         assert_eq!(
             mid_range,
-            vec![(&2, &"c"), (&2, &"d"),]
-                .into_iter()
-                .collect::<BTreeSet<_>>()
+            vec![(&2, &"c"), (&2, &"d"),].into_iter().collect::<BTreeSet<_>>()
         );
     }
 
@@ -677,9 +656,7 @@ mod tests {
         let mid_range = map.range(2..3).collect::<BTreeSet<_>>();
         assert_eq!(
             mid_range,
-            vec![(&2, &"c"), (&2, &"d"),]
-                .into_iter()
-                .collect::<BTreeSet<_>>()
+            vec![(&2, &"c"), (&2, &"d"),].into_iter().collect::<BTreeSet<_>>()
         );
 
         let reverse_range = map.range(1..4).rev().collect::<BTreeSet<_>>();
@@ -711,31 +688,22 @@ mod tests {
 
         assert_eq!(
             range,
-            vec![(&1, &"b"), (&1, &"a"),]
-                .into_iter()
-                .collect::<BTreeSet<_>>()
+            vec![(&1, &"b"), (&1, &"a"),].into_iter().collect::<BTreeSet<_>>()
         );
 
         let range = map.get(&2).collect::<BTreeSet<_>>();
         assert_eq!(
             range,
-            vec![(&2, &"d"), (&2, &"c"),]
-                .into_iter()
-                .collect::<BTreeSet<_>>()
+            vec![(&2, &"d"), (&2, &"c"),].into_iter().collect::<BTreeSet<_>>()
         );
 
         let range = map.get(&3).collect::<BTreeSet<_>>();
-        assert_eq!(
-            range,
-            vec![(&3, &"e"),].into_iter().collect::<BTreeSet<_>>()
-        );
+        assert_eq!(range, vec![(&3, &"e"),].into_iter().collect::<BTreeSet<_>>());
 
         let range = map.get(&4).collect::<BTreeSet<_>>();
         assert_eq!(
             range,
-            vec![(&4, &"g"), (&4, &"f"),]
-                .into_iter()
-                .collect::<BTreeSet<_>>()
+            vec![(&4, &"g"), (&4, &"f"),].into_iter().collect::<BTreeSet<_>>()
         );
     }
 

--- a/src/concurrent/operation.rs
+++ b/src/concurrent/operation.rs
@@ -35,10 +35,7 @@ where
                     if Arc::ptr_eq(entry.value(), &old_node) {
                         let mut cdc = vec![];
                         #[cfg(feature = "cdc")]
-                        let max_value = guard
-                            .max()
-                            .expect("node should be non empty if split")
-                            .clone();
+                        let max_value = guard.max().expect("node should be non empty if split").clone();
                         entry.remove();
                         let mut new_vec = guard.halve();
 

--- a/src/concurrent/ref.rs
+++ b/src/concurrent/ref.rs
@@ -1,11 +1,11 @@
-use std::marker::PhantomData;
-use parking_lot::{ArcMutexGuard, RawMutex};
 use crate::core::node::NodeLike;
+use parking_lot::{ArcMutexGuard, RawMutex};
+use std::marker::PhantomData;
 
 pub struct Ref<T: Ord + Clone + Send, Node: NodeLike<T> + Send> {
     pub(super) node_guard: ArcMutexGuard<RawMutex, Node>,
     pub(super) position: usize,
-    pub(super) phantom_data: PhantomData<T>
+    pub(super) phantom_data: PhantomData<T>,
 }
 
 impl<T: Ord + Clone + Send, Node: NodeLike<T> + Send> Ref<T, Node> {

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -139,8 +139,7 @@ where
         loop {
             let mut cdc = vec![];
             let _global_guard = self.index_lock.read();
-            let target_node_entry = match self.index.lower_bound(std::ops::Bound::Included(&value))
-            {
+            let target_node_entry = match self.index.lower_bound(std::ops::Bound::Included(&value)) {
                 Some(entry) => entry,
                 None => {
                     if let Some(last) = self.index.back() {
@@ -365,9 +364,7 @@ where
         loop {
             let mut cdc = vec![];
             let _global_guard = self.index_lock.read();
-            if let Some(target_node_entry) =
-                self.index.lower_bound(std::ops::Bound::Included(&value))
-            {
+            if let Some(target_node_entry) = self.index.lower_bound(std::ops::Bound::Included(&value)) {
                 let mut node_guard = target_node_entry.value().lock_arc();
                 let old_max = node_guard.max().cloned();
                 let deleted = NodeLike::delete(&mut *node_guard, value);
@@ -383,9 +380,7 @@ where
                             // is correct as node is locked and current thread is the only that can
                             // fetch event_id, so events for this node will have monotonic id's.
                             event_id: self.event_id.fetch_add(1, Ordering::Relaxed).into(),
-                            max_value: old_max
-                                .clone()
-                                .expect("Max value should exist as Node is not empty"),
+                            max_value: old_max.clone().expect("Max value should exist as Node is not empty"),
                             value: deleted.clone(),
                             index: idx,
                         };
@@ -519,10 +514,7 @@ where
         None
     }
     pub fn len(&self) -> usize {
-        self.index
-            .iter()
-            .map(|node| node.value().lock().len())
-            .sum()
+        self.index.iter().map(|node| node.value().lock().len()).sum()
     }
     pub fn capacity(&self) -> usize {
         self.index
@@ -676,9 +668,7 @@ where
                     if let Some(current_node_entry) = self.tree.index.iter().find(|e| {
                         Arc::ptr_eq(
                             e.value(),
-                            self.current_front_node
-                                .as_ref()
-                                .expect("was just set before"),
+                            self.current_front_node.as_ref().expect("was just set before"),
                         )
                     }) {
                         if let Some(next_node_entry) = current_node_entry.next() {
@@ -686,10 +676,8 @@ where
 
                             if let Some(back_entry) = self.current_back_node.as_ref() {
                                 if Arc::ptr_eq(next_node_entry.value(), back_entry) {
-                                    self.current_front_node_guard =
-                                        self.current_back_node_guard.take();
-                                    self.current_front_node_iter =
-                                        self.current_back_node_iter.take();
+                                    self.current_front_node_guard = self.current_back_node_guard.take();
+                                    self.current_front_node_iter = self.current_back_node_iter.take();
                                 }
                                 continue;
                             }
@@ -739,15 +727,9 @@ where
                 });
 
                 if let Some(current_front_value) = self.current_front_value.as_ref() {
-                    let g = self
-                        .current_front_node_guard
-                        .as_mut()
-                        .expect("was just set before");
+                    let g = self.current_front_node_guard.as_mut().expect("was just set before");
                     if let Some(rank) = g.rank(Bound::Excluded(current_front_value), true) {
-                        let i = self
-                            .current_front_node_iter
-                            .as_mut()
-                            .expect("was just set before");
+                        let i = self.current_front_node_iter.as_mut().expect("was just set before");
                         if let Some(v) = i.nth(rank + 1) {
                             if let Some(current_back_value) = self.current_back_value.as_ref() {
                                 if v.ge(current_back_value) {
@@ -791,12 +773,8 @@ where
                             continue;
                         }
 
-                        self.current_back_node_guard = Some(
-                            self.current_back_node
-                                .as_ref()
-                                .expect("was just set before")
-                                .lock_arc(),
-                        );
+                        self.current_back_node_guard =
+                            Some(self.current_back_node.as_ref().expect("was just set before").lock_arc());
                         self.current_back_node_iter = Some(unsafe {
                             std::mem::transmute(
                                 self.current_back_node_guard
@@ -831,33 +809,24 @@ where
                     self.current_back_node_iter = None;
                     self.current_back_node_guard = None;
 
-                    if let Some(current_node_entry) = self.tree.index.iter().find(|e| {
-                        Arc::ptr_eq(
-                            e.value(),
-                            self.current_back_node
-                                .as_ref()
-                                .expect("was just set before"),
-                        )
-                    }) {
+                    if let Some(current_node_entry) =
+                        self.tree.index.iter().find(|e| {
+                            Arc::ptr_eq(e.value(), self.current_back_node.as_ref().expect("was just set before"))
+                        })
+                    {
                         if let Some(prev_node_entry) = current_node_entry.prev() {
                             self.current_back_node = Some(prev_node_entry.value().clone());
 
                             if let Some(front_entry) = self.current_front_node.as_ref() {
                                 if Arc::ptr_eq(prev_node_entry.value(), front_entry) {
-                                    self.current_back_node_guard =
-                                        self.current_front_node_guard.take();
-                                    self.current_back_node_iter =
-                                        self.current_front_node_iter.take();
+                                    self.current_back_node_guard = self.current_front_node_guard.take();
+                                    self.current_back_node_iter = self.current_front_node_iter.take();
                                 }
                                 continue;
                             }
 
-                            self.current_back_node_guard = Some(
-                                self.current_back_node
-                                    .as_ref()
-                                    .expect("was just set before")
-                                    .lock_arc(),
-                            );
+                            self.current_back_node_guard =
+                                Some(self.current_back_node.as_ref().expect("was just set before").lock_arc());
                             self.current_back_node_iter = Some(unsafe {
                                 std::mem::transmute(
                                     self.current_back_node_guard
@@ -881,12 +850,8 @@ where
                     }
                 }
             } else {
-                self.current_back_node_guard = Some(
-                    self.current_back_node
-                        .as_ref()
-                        .expect("was just set before")
-                        .lock_arc(),
-                );
+                self.current_back_node_guard =
+                    Some(self.current_back_node.as_ref().expect("was just set before").lock_arc());
                 self.current_back_node_iter = Some(unsafe {
                     std::mem::transmute(
                         self.current_back_node_guard
@@ -897,15 +862,9 @@ where
                 });
 
                 if let Some(current_back_value) = self.current_back_value.as_ref() {
-                    let g = self
-                        .current_back_node_guard
-                        .as_mut()
-                        .expect("was just set before");
+                    let g = self.current_back_node_guard.as_mut().expect("was just set before");
                     if let Some(rank) = g.rank(Bound::Excluded(current_back_value), false) {
-                        let i = self
-                            .current_back_node_iter
-                            .as_mut()
-                            .expect("was just set before");
+                        let i = self.current_back_node_iter.as_mut().expect("was just set before");
                         if let Some(v) = i.nth_back(rank + 1) {
                             if let Some(current_front_value) = self.current_front_value.as_ref() {
                                 if v.le(current_front_value) {
@@ -925,10 +884,7 @@ where
     }
 }
 
-impl<'a, T: Debug + Ord + Clone + Send, Node: NodeLike<T> + Send + 'static> FusedIterator
-    for Iter<'a, T, Node>
-{
-}
+impl<'a, T: Debug + Ord + Clone + Send, Node: NodeLike<T> + Send + 'static> FusedIterator for Iter<'a, T, Node> {}
 
 impl<'a, T, Node> IntoIterator for &'a BTreeSet<T, Node>
 where
@@ -1034,11 +990,7 @@ where
         if front_value.is_none() && back_value.is_none() {
             // in this case we iter full or no iter at all
             if start_bound != Bound::Unbounded || end_bound != Bound::Unbounded {
-                if let Some(max) = btree
-                    .index
-                    .back()
-                    .and_then(|e| e.value().lock_arc().max().cloned())
-                {
+                if let Some(max) = btree.index.back().and_then(|e| e.value().lock_arc().max().cloned()) {
                     if let Bound::Included(v) = start_bound {
                         if v > max.borrow() {
                             met = true;
@@ -1050,11 +1002,7 @@ where
                     }
                 }
 
-                if let Some(min) = btree
-                    .index
-                    .front()
-                    .and_then(|e| e.value().lock_arc().min().cloned())
-                {
+                if let Some(min) = btree.index.front().and_then(|e| e.value().lock_arc().min().cloned()) {
                     if let Bound::Included(v) = end_bound {
                         if v < min.borrow() {
                             met = true;
@@ -1300,8 +1248,7 @@ where
                 front_entry_guard.drain(potential_front_position..);
                 if !front_entry_guard.is_empty() {
                     let new_front_max = front_entry_guard.last().unwrap().clone();
-                    self.index
-                        .insert(new_front_max, front_entry.value().clone());
+                    self.index.insert(new_front_max, front_entry.value().clone());
                 }
 
                 // The back from the right
@@ -1463,12 +1410,7 @@ mod tests {
 
             let expected_next_back = 20 - i;
             let actual_next_back = iter.next_back();
-            assert_eq!(
-                actual_next_back,
-                Some(&expected_next_back),
-                "Tree: {:?}",
-                tree
-            );
+            assert_eq!(actual_next_back, Some(&expected_next_back), "Tree: {:?}", tree);
         }
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next_back(), None);
@@ -1499,12 +1441,7 @@ mod tests {
         let btree: BTreeSet<usize> = BTreeSet::from_iter(0..10);
         assert_eq!(btree.range((Included(5), Included(10))).count(), 5);
         assert_eq!(btree.range((Included(5), Included(11))).count(), 5);
-        assert_eq!(
-            btree
-                .range((Included(5), Included(10 + DEFAULT_INNER_SIZE)))
-                .count(),
-            5
-        );
+        assert_eq!(btree.range((Included(5), Included(10 + DEFAULT_INNER_SIZE))).count(), 5);
         assert_eq!(btree.range((Included(0), Included(11))).count(), 10);
     }
 
@@ -1531,10 +1468,7 @@ mod tests {
             btree.range(0..=DEFAULT_INNER_SIZE + 1).count(),
             (0..=DEFAULT_INNER_SIZE + 1).count()
         );
-        assert_eq!(
-            btree.iter().rev().count(),
-            (0..(DEFAULT_INNER_SIZE + 10)).count()
-        );
+        assert_eq!(btree.iter().rev().count(), (0..(DEFAULT_INNER_SIZE + 10)).count());
         assert_eq!(
             btree.range(0..DEFAULT_INNER_SIZE).rev().count(),
             (0..DEFAULT_INNER_SIZE).count()
@@ -1566,12 +1500,7 @@ mod tests {
         assert_eq!(btree.range(..1).rev().count(), 0);
 
         assert_eq!(btree.range(..DEFAULT_INNER_SIZE).count(), 0);
-        assert_eq!(
-            btree
-                .range(DEFAULT_INNER_SIZE..DEFAULT_INNER_SIZE * 2)
-                .count(),
-            0
-        );
+        assert_eq!(btree.range(DEFAULT_INNER_SIZE..DEFAULT_INNER_SIZE * 2).count(), 0);
     }
 
     #[test]
@@ -1685,11 +1614,7 @@ mod tests {
         for i in 0..NUM_ELEMENTS {
             set.insert(i);
         }
-        assert_eq!(
-            set.len(),
-            NUM_ELEMENTS as usize,
-            "Incorrect size after insertion"
-        );
+        assert_eq!(set.len(), NUM_ELEMENTS as usize, "Incorrect size after insertion");
 
         let num_threads = 8;
         let elements_per_thread = NUM_ELEMENTS / num_threads;
@@ -1710,21 +1635,13 @@ mod tests {
             handle.join().unwrap();
         }
 
-        assert_eq!(
-            set.len(),
-            NUM_ELEMENTS as usize / 2,
-            "Incorrect size after removal"
-        );
+        assert_eq!(set.len(), NUM_ELEMENTS as usize / 2, "Incorrect size after removal");
 
         for i in 0..NUM_ELEMENTS {
             if i % 2 == 0 {
                 assert!(set.contains(&i), "Even number {} should be in the set", i);
             } else {
-                assert!(
-                    !set.contains(&i),
-                    "Odd number {} should not be in the set",
-                    i
-                );
+                assert!(!set.contains(&i), "Odd number {} should not be in the set", i);
             }
         }
     }
@@ -1777,10 +1694,7 @@ mod tests {
         assert_eq!(set.range(5..=8).collect::<Vec<_>>(), vec![&5, &6, &7, &8]);
         assert_eq!(set.range(5..8).collect::<Vec<_>>(), vec![&5, &6, &7]);
 
-        assert_eq!(
-            set.range(10..=13).collect::<Vec<_>>(),
-            vec![&10, &11, &12, &13]
-        );
+        assert_eq!(set.range(10..=13).collect::<Vec<_>>(), vec![&10, &11, &12, &13]);
         assert_eq!(set.range(10..13).collect::<Vec<_>>(), vec![&10, &11, &12]);
 
         // Last value of the node
@@ -1804,23 +1718,11 @@ mod tests {
         assert_eq!(set.range(2..5).collect::<Vec<_>>(), vec![&2, &3, &4]);
 
         // Full node
-        assert_eq!(
-            set.range(0..=4).collect::<Vec<_>>(),
-            vec![&0, &1, &2, &3, &4]
-        );
-        assert_eq!(
-            set.range(0..5).collect::<Vec<_>>(),
-            vec![&0, &1, &2, &3, &4]
-        );
+        assert_eq!(set.range(0..=4).collect::<Vec<_>>(), vec![&0, &1, &2, &3, &4]);
+        assert_eq!(set.range(0..5).collect::<Vec<_>>(), vec![&0, &1, &2, &3, &4]);
 
-        assert_eq!(
-            set.range(5..=9).collect::<Vec<_>>(),
-            vec![&5, &6, &7, &8, &9]
-        );
-        assert_eq!(
-            set.range(5..10).collect::<Vec<_>>(),
-            vec![&5, &6, &7, &8, &9]
-        );
+        assert_eq!(set.range(5..=9).collect::<Vec<_>>(), vec![&5, &6, &7, &8, &9]);
+        assert_eq!(set.range(5..10).collect::<Vec<_>>(), vec![&5, &6, &7, &8, &9]);
 
         assert_eq!(
             set.range(10..=19).collect::<Vec<_>>(),
@@ -1835,10 +1737,7 @@ mod tests {
         assert_eq!(set.range(3..=6).collect::<Vec<_>>(), vec![&3, &4, &5, &6]);
         assert_eq!(set.range(3..7).collect::<Vec<_>>(), vec![&3, &4, &5, &6]);
 
-        assert_eq!(
-            set.range(8..=11).collect::<Vec<_>>(),
-            vec![&8, &9, &10, &11]
-        );
+        assert_eq!(set.range(8..=11).collect::<Vec<_>>(), vec![&8, &9, &10, &11]);
         assert_eq!(set.range(8..12).collect::<Vec<_>>(), vec![&8, &9, &10, &11]);
 
         // REVERSED
@@ -1854,26 +1753,14 @@ mod tests {
         assert_eq!(set.range(10..11).rev().collect::<Vec<_>>(), vec![&10]);
 
         // From first value to middle
-        assert_eq!(
-            set.range(0..=3).rev().collect::<Vec<_>>(),
-            vec![&3, &2, &1, &0]
-        );
+        assert_eq!(set.range(0..=3).rev().collect::<Vec<_>>(), vec![&3, &2, &1, &0]);
         assert_eq!(set.range(0..3).rev().collect::<Vec<_>>(), vec![&2, &1, &0]);
 
-        assert_eq!(
-            set.range(5..=8).rev().collect::<Vec<_>>(),
-            vec![&8, &7, &6, &5]
-        );
+        assert_eq!(set.range(5..=8).rev().collect::<Vec<_>>(), vec![&8, &7, &6, &5]);
         assert_eq!(set.range(5..8).rev().collect::<Vec<_>>(), vec![&7, &6, &5]);
 
-        assert_eq!(
-            set.range(10..=13).rev().collect::<Vec<_>>(),
-            vec![&13, &12, &11, &10]
-        );
-        assert_eq!(
-            set.range(10..13).rev().collect::<Vec<_>>(),
-            vec![&12, &11, &10]
-        );
+        assert_eq!(set.range(10..=13).rev().collect::<Vec<_>>(), vec![&13, &12, &11, &10]);
+        assert_eq!(set.range(10..13).rev().collect::<Vec<_>>(), vec![&12, &11, &10]);
 
         // Last value of the node
         assert_eq!(set.range(4..=4).rev().collect::<Vec<_>>(), vec![&4]);
@@ -1886,14 +1773,8 @@ mod tests {
         assert_eq!(set.range(19..20).rev().collect::<Vec<_>>(), vec![&19]);
 
         // From middle to last value of the node
-        assert_eq!(
-            set.range(17..=19).rev().collect::<Vec<_>>(),
-            vec![&19, &18, &17]
-        );
-        assert_eq!(
-            set.range(17..20).rev().collect::<Vec<_>>(),
-            vec![&19, &18, &17]
-        );
+        assert_eq!(set.range(17..=19).rev().collect::<Vec<_>>(), vec![&19, &18, &17]);
+        assert_eq!(set.range(17..20).rev().collect::<Vec<_>>(), vec![&19, &18, &17]);
 
         assert_eq!(set.range(7..=9).rev().collect::<Vec<_>>(), vec![&9, &8, &7]);
         assert_eq!(set.range(7..10).rev().collect::<Vec<_>>(), vec![&9, &8, &7]);
@@ -1902,23 +1783,11 @@ mod tests {
         assert_eq!(set.range(2..5).rev().collect::<Vec<_>>(), vec![&4, &3, &2]);
 
         // Full node
-        assert_eq!(
-            set.range(0..=4).rev().collect::<Vec<_>>(),
-            vec![&4, &3, &2, &1, &0]
-        );
-        assert_eq!(
-            set.range(0..5).rev().collect::<Vec<_>>(),
-            vec![&4, &3, &2, &1, &0]
-        );
+        assert_eq!(set.range(0..=4).rev().collect::<Vec<_>>(), vec![&4, &3, &2, &1, &0]);
+        assert_eq!(set.range(0..5).rev().collect::<Vec<_>>(), vec![&4, &3, &2, &1, &0]);
 
-        assert_eq!(
-            set.range(5..=9).rev().collect::<Vec<_>>(),
-            vec![&9, &8, &7, &6, &5]
-        );
-        assert_eq!(
-            set.range(5..10).rev().collect::<Vec<_>>(),
-            vec![&9, &8, &7, &6, &5]
-        );
+        assert_eq!(set.range(5..=9).rev().collect::<Vec<_>>(), vec![&9, &8, &7, &6, &5]);
+        assert_eq!(set.range(5..10).rev().collect::<Vec<_>>(), vec![&9, &8, &7, &6, &5]);
 
         assert_eq!(
             set.range(10..=19).rev().collect::<Vec<_>>(),
@@ -1930,23 +1799,11 @@ mod tests {
         );
 
         // Node intersection
-        assert_eq!(
-            set.range(3..=6).rev().collect::<Vec<_>>(),
-            vec![&6, &5, &4, &3]
-        );
-        assert_eq!(
-            set.range(3..7).rev().collect::<Vec<_>>(),
-            vec![&6, &5, &4, &3]
-        );
+        assert_eq!(set.range(3..=6).rev().collect::<Vec<_>>(), vec![&6, &5, &4, &3]);
+        assert_eq!(set.range(3..7).rev().collect::<Vec<_>>(), vec![&6, &5, &4, &3]);
 
-        assert_eq!(
-            set.range(8..=11).rev().collect::<Vec<_>>(),
-            vec![&11, &10, &9, &8]
-        );
-        assert_eq!(
-            set.range(8..12).rev().collect::<Vec<_>>(),
-            vec![&11, &10, &9, &8]
-        );
+        assert_eq!(set.range(8..=11).rev().collect::<Vec<_>>(), vec![&11, &10, &9, &8]);
+        assert_eq!(set.range(8..12).rev().collect::<Vec<_>>(), vec![&11, &10, &9, &8]);
 
         // Non-existent range
         assert!(set.range(20..).collect::<Vec<_>>().is_empty());

--- a/src/core/multipair.rs
+++ b/src/core/multipair.rs
@@ -2,9 +2,9 @@ use std::fmt::Debug;
 use std::{borrow::Borrow, mem::MaybeUninit};
 
 use core::cmp::Ordering;
+use fastrand;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use fastrand;
 
 use crate::core::pair::Pair;
 
@@ -18,13 +18,25 @@ pub struct MultiPair<K, V> {
 
 impl<K: Ord, V: PartialEq> MultiPair<K, V> {
     pub fn new(key: K, value: V) -> Self {
-        Self { key, value, discriminator: fastrand::u64(..) }
+        Self {
+            key,
+            value,
+            discriminator: fastrand::u64(..),
+        }
     }
     pub fn with_infimum(key: K) -> Self {
-        Self { key, value: unsafe { MaybeUninit::uninit().assume_init() }, discriminator: INFIMUM }
+        Self {
+            key,
+            value: unsafe { MaybeUninit::uninit().assume_init() },
+            discriminator: INFIMUM,
+        }
     }
     pub fn with_supremum(key: K) -> Self {
-        Self { key, value: unsafe { MaybeUninit::uninit().assume_init() }, discriminator: SUPREMUM }
+        Self {
+            key,
+            value: unsafe { MaybeUninit::uninit().assume_init() },
+            discriminator: SUPREMUM,
+        }
     }
 }
 
@@ -43,7 +55,9 @@ impl<K: Ord, V: PartialEq> Ord for MultiPair<K, V> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.key.cmp(&other.key) {
             Ordering::Equal => {
-                if (self.discriminator == INFIMUM || other.discriminator == INFIMUM) || (self.discriminator == SUPREMUM || other.discriminator == SUPREMUM) {
+                if (self.discriminator == INFIMUM || other.discriminator == INFIMUM)
+                    || (self.discriminator == SUPREMUM || other.discriminator == SUPREMUM)
+                {
                     return self.discriminator.cmp(&other.discriminator);
                 }
 
@@ -52,7 +66,7 @@ impl<K: Ord, V: PartialEq> Ord for MultiPair<K, V> {
                 }
 
                 self.discriminator.cmp(&other.discriminator)
-            },
+            }
             ord => ord,
         }
     }
@@ -114,22 +128,22 @@ mod test {
         let p1 = MultiPair::new(1, "a");
         let p2 = MultiPair::new(1, "b");
         let p3 = MultiPair::new(2, "c");
-     
+
         NodeLike::insert(&mut vec, p1.clone());
         NodeLike::insert(&mut vec, p2.clone());
-        assert_eq!(vec.len(), 2); 
+        assert_eq!(vec.len(), 2);
 
         NodeLike::insert(&mut vec, p1.clone());
         assert_eq!(vec.len(), 2);
-     
+
         NodeLike::insert(&mut vec, p3.clone());
         assert_eq!(vec.len(), 3);
-     }
+    }
 
-     #[test]
-     fn range_bounds() {
+    #[test]
+    fn range_bounds() {
         let mut vec = Vec::new();
-    
+
         let p1a = MultiPair::new(1, "a");
         let p1b = MultiPair::new(1, "b");
         let p1c = MultiPair::new(1, "c");
@@ -153,7 +167,10 @@ mod test {
         NodeLike::insert(&mut vec, p3c.clone());
         assert_eq!(vec.len(), 10);
 
-        let start_1 = vec.rank(Included(&MultiPair::with_infimum(1)), true).or_else(|| Some(0)).unwrap();
+        let start_1 = vec
+            .rank(Included(&MultiPair::with_infimum(1)), true)
+            .or_else(|| Some(0))
+            .unwrap();
         let end_1 = vec.rank(Excluded(&MultiPair::with_supremum(1)), true).unwrap();
         let range_1 = &vec[start_1..=end_1];
         assert_eq!(range_1.len(), 3);
@@ -185,5 +202,5 @@ mod test {
         let range_4 = &vec[start_4..=end_4];
         assert_eq!(range_4.len(), 1);
         assert!(range_4.contains(&p4a));
-     }
+    }
 }

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -40,7 +40,9 @@ pub trait NodeLike<T: Ord> {
     #[allow(dead_code)]
     fn min(&self) -> Option<&T>;
     #[allow(dead_code)]
-    fn iter<'a>(&'a self) -> std::slice::Iter<'a, T> where T: 'a;
+    fn iter<'a>(&'a self) -> std::slice::Iter<'a, T>
+    where
+        T: 'a;
 }
 
 #[inline]
@@ -85,7 +87,7 @@ where
 {
     match bound {
         // If the bound is unbounded, then no skipping is needed
-        std::ops::Bound::Unbounded => { None }
+        std::ops::Bound::Unbounded => None,
         std::ops::Bound::Included(value) | std::ops::Bound::Excluded(value) => {
             let mut positions_to_skip = -1;
             let iter = if forward {
@@ -99,9 +101,12 @@ where
                     for item in iter {
                         match item.borrow().cmp(&value) {
                             Ordering::Less => positions_to_skip += 1,
-                                Ordering::Equal => match bound {
+                            Ordering::Equal => match bound {
                                 std::ops::Bound::Included(_) => break,
-                                std::ops::Bound::Excluded(_) => { positions_to_skip += 1; break },
+                                std::ops::Bound::Excluded(_) => {
+                                    positions_to_skip += 1;
+                                    break;
+                                }
                                 _ => unreachable!(),
                             },
                             Ordering::Greater => break,
@@ -114,7 +119,10 @@ where
                             Ordering::Greater => positions_to_skip += 1,
                             Ordering::Equal => match bound {
                                 std::ops::Bound::Included(_) => break,
-                                std::ops::Bound::Excluded(_) => { positions_to_skip += 1; break },
+                                std::ops::Bound::Excluded(_) => {
+                                    positions_to_skip += 1;
+                                    break;
+                                }
                                 _ => unreachable!(),
                             },
                             Ordering::Less => break,
@@ -227,7 +235,8 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     }
     #[inline]
     fn iter<'a>(&'a self) -> std::slice::Iter<'a, T>
-    where T: 'a
+    where
+        T: 'a,
     {
         self.deref().iter()
     }
@@ -244,33 +253,98 @@ mod tests {
         assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, true), None);
         assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, false), None);
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), true), Some(1));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), true), Some(3));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), true), Some(4));
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), true),
+            Some(1)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), true),
+            Some(3)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), true),
+            Some(4)
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), true), Some(0));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), true), Some(2));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), true), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), true), Some(4));
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), true),
+            Some(0)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), true),
+            Some(2)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), true),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), true),
+            Some(4)
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), false), Some(3));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), false), Some(1));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), false), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), false),
+            Some(3)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), false),
+            Some(1)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), false),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), false),
+            None
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), false), Some(2));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), false), Some(0));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), false),
+            Some(2)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), false),
+            Some(0)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), false),
+            None
+        );
 
         let empty: Vec<i32> = vec![];
-        assert_eq!(compute_positions_to_skip(&empty, std::ops::Bound::Included(&1), true), None);
-        assert_eq!(compute_positions_to_skip(&empty, std::ops::Bound::Excluded(&1), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&empty, std::ops::Bound::Included(&1), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&empty, std::ops::Bound::Excluded(&1), false),
+            None
+        );
     }
-
 }

--- a/src/core/pair.rs
+++ b/src/core/pair.rs
@@ -5,8 +5,7 @@ use std::borrow::Borrow;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, Hash)]
-pub struct Pair<K, V>
-{
+pub struct Pair<K, V> {
     pub key: K,
     pub value: V,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ enum NodeEntry {
     },
     Empty {
         node_idx: usize,
-    }
+    },
 }
 
 impl<T: Ord> BTreeSet<T> {
@@ -116,9 +116,7 @@ impl<T: Ord> BTreeSet<T> {
     /// let mut set: BTreeSet<i32> = BTreeSet::new();
     /// ```
     pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
+        Self { ..Default::default() }
     }
     /// Makes a new, empty `BTreeSet` with the given maximum node size. Allocates one vec with
     /// the capacity set to be the specified node size.
@@ -203,8 +201,7 @@ impl<T: Ord> BTreeSet<T> {
         Q: Ord + ?Sized,
     {
         let node_idx = self.locate_node(value);
-        let position_within_node =
-            self.inner[node_idx].partition_point(|item| item.borrow() < value);
+        let position_within_node = self.inner[node_idx].partition_point(|item| item.borrow() < value);
 
         (node_idx, position_within_node)
     }
@@ -518,13 +515,16 @@ impl<T: Ord> BTreeSet<T> {
         R: FnMut(&Q) -> bool,
     {
         let (node_idx, position_within_node) = self.locate_value_cmp(cmp);
-        self.inner.get(node_idx)
-        .and_then(|candidate_node| candidate_node.get(position_within_node))
-        .filter(|&candidate_value| cmp2(candidate_value.borrow()))
-        .map(|_| NodeEntry::Exist { node_idx, position_within_node })
-        .unwrap_or(NodeEntry::Empty { node_idx })
+        self.inner
+            .get(node_idx)
+            .and_then(|candidate_node| candidate_node.get(position_within_node))
+            .filter(|&candidate_value| cmp2(candidate_value.borrow()))
+            .map(|_| NodeEntry::Exist {
+                node_idx,
+                position_within_node,
+            })
+            .unwrap_or(NodeEntry::Empty { node_idx })
     }
-
 
     fn delete_cmp<P, Q, R>(&mut self, cmp: P, cmp2: R) -> (Option<T>, bool)
     where
@@ -534,9 +534,10 @@ impl<T: Ord> BTreeSet<T> {
         R: FnMut(&Q) -> bool,
     {
         let removal = match self.find_cmp(cmp, cmp2) {
-            NodeEntry::Exist { node_idx, position_within_node } => {
-                Some(self.delete_at(node_idx, position_within_node))
-            }
+            NodeEntry::Exist {
+                node_idx,
+                position_within_node,
+            } => Some(self.delete_at(node_idx, position_within_node)),
             NodeEntry::Empty { .. } => None,
         };
 
@@ -1119,8 +1120,7 @@ impl<T: Ord> BTreeSet<T> {
         R: RangeBounds<usize>,
     {
         let mut global_front_idx: usize = 0;
-        let mut global_back_idx: usize =
-            self.index.prefix_sum(self.inner.len(), 0).saturating_sub(1);
+        let mut global_back_idx: usize = self.index.prefix_sum(self.inner.len(), 0).saturating_sub(1);
 
         // Solving global indexes
         let start = range.start_bound();
@@ -1244,10 +1244,8 @@ impl<T: Ord> BTreeSet<T> {
     where
         R: RangeBounds<usize>,
     {
-        let (
-            (global_front_idx, front_node_idx, front_start_idx),
-            (global_back_idx, back_node_idx, back_start_idx),
-        ) = self.resolve_range(range);
+        let ((global_front_idx, front_node_idx, front_start_idx), (global_back_idx, back_node_idx, back_start_idx)) =
+            self.resolve_range(range);
 
         let front_iter = if front_node_idx < self.inner.len() {
             Some(self.inner[front_node_idx][front_start_idx..].iter())
@@ -1374,8 +1372,7 @@ where
             if self.current_front_node_idx >= self.btree.inner.len() {
                 return None;
             }
-            self.current_front_iterator =
-                Some(self.btree.inner[self.current_front_node_idx].iter());
+            self.current_front_iterator = Some(self.btree.inner[self.current_front_node_idx].iter());
 
             self.next()
         }
@@ -1390,11 +1387,7 @@ where
         if self.current_front_idx == self.current_back_idx {
             return None;
         }
-        if let Some(value) = self
-            .current_back_iterator
-            .as_mut()
-            .and_then(|i| i.next_back())
-        {
+        if let Some(value) = self.current_back_iterator.as_mut().and_then(|i| i.next_back()) {
             self.current_back_idx -= 1;
             Some(value)
         } else {
@@ -1866,10 +1859,7 @@ where
         self.key
     }
     pub fn insert(self, value: V) -> &'a mut V {
-        let rank = self
-            .map
-            .set
-            .rank_cmp(|item: &Pair<K, V>| &item.key < &self.key);
+        let rank = self.map.set.rank_cmp(|item: &Pair<K, V>| &item.key < &self.key);
         self.map.insert(self.key, value);
 
         self.map.get_mut_index(rank).unwrap()
@@ -2172,9 +2162,7 @@ where
         K: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        let (node_idx, position_within_node) = self
-            .set
-            .locate_value_cmp(|item: &Pair<K, V>| item.key.borrow() < key);
+        let (node_idx, position_within_node) = self.set.locate_value_cmp(|item: &Pair<K, V>| item.key.borrow() < key);
         if let Some(candidate_node) = self.set.inner.get(node_idx) {
             if let Some(candidate_value) = candidate_node.get(position_within_node) {
                 if candidate_value.key.borrow() == key {
@@ -2209,12 +2197,8 @@ where
         K: Borrow<Q> + Ord,
         Q: Ord,
     {
-        let (node_idx, position_within_node) = self
-            .set
-            .locate_value_cmp(|item: &Pair<K, V>| item.key.borrow() < key);
-        if self.set.inner.get(node_idx).is_some()
-            && self.set.inner[node_idx].get(position_within_node).is_some()
-        {
+        let (node_idx, position_within_node) = self.set.locate_value_cmp(|item: &Pair<K, V>| item.key.borrow() < key);
+        if self.set.inner.get(node_idx).is_some() && self.set.inner[node_idx].get(position_within_node).is_some() {
             let entry = self.set.inner[node_idx].get_mut(position_within_node)?;
             if key == entry.key.borrow() {
                 return Some(&mut entry.value);
@@ -2277,16 +2261,17 @@ where
         let cmp2 = |item: &Pair<K, V>| item.key == key;
 
         match self.set.find_cmp(cmp, cmp2) {
-            NodeEntry::Exist { node_idx, position_within_node } => {
-                std::mem::swap(
-                    &mut self.set.inner[node_idx][position_within_node].value,
-                    &mut value);
+            NodeEntry::Exist {
+                node_idx,
+                position_within_node,
+            } => {
+                std::mem::swap(&mut self.set.inner[node_idx][position_within_node].value, &mut value);
                 Some(value)
-            },
+            }
             NodeEntry::Empty { node_idx } => {
                 self.set.insert_at(node_idx, Pair { key, value });
                 None
-            },
+            }
         }
     }
     /// Creates a consuming iterator visiting all the keys, in sorted order.
@@ -2370,9 +2355,7 @@ where
     /// assert_eq!((*first_key, *first_value), (1, "a"));
     /// ```
     pub fn iter(&self) -> IterMap<K, V> {
-        IterMap {
-            inner: self.set.iter(),
-        }
+        IterMap { inner: self.set.iter() }
     }
     /// Gets a mutable iterator over the entries of the map, sorted by key.
     ///
@@ -2415,7 +2398,7 @@ where
                 inner,
                 current_front_node_idx: 0,
                 current_front_idx: 0,
-                current_back_node_idx: 0,  // Same as front for single node
+                current_back_node_idx: 0, // Same as front for single node
                 current_back_idx: len.wrapping_sub(1),
                 current_front_iterator: front_iter,
                 current_back_iterator: back_iter,
@@ -2462,9 +2445,7 @@ where
     /// assert_eq!(keys, [1, 2]);
     /// ```
     pub fn keys(&self) -> Keys<K, V> {
-        Keys {
-            inner: self.set.iter(),
-        }
+        Keys { inner: self.set.iter() }
     }
     /// Returns the last key-value pair in the map.
     /// The key in this pair is the maximum key in the map.
@@ -2523,9 +2504,7 @@ where
     /// map.insert(1, "a");
     /// ```
     pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
+        Self { ..Default::default() }
     }
     /// Makes a new, empty `BTreeSet` with the given maximum node size. Allocates one vec with
     /// the capacity set to be the specified node size.
@@ -2670,22 +2649,14 @@ where
         R: RangeBounds<Q>,
     {
         let start_idx = match range.start_bound() {
-            Bound::Included(bound) => self
-                .set
-                .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound),
-            Bound::Excluded(bound) => self
-                .set
-                .rank_cmp(|item: &Pair<K, V>| item.key.borrow() <= bound),
+            Bound::Included(bound) => self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound),
+            Bound::Excluded(bound) => self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() <= bound),
             Bound::Unbounded => 0,
         };
         let end_idx = match range.end_bound() {
-            Bound::Included(bound) => self
-                .set
-                .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound),
+            Bound::Included(bound) => self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound),
             Bound::Excluded(bound) => {
-                let rank = self
-                    .set
-                    .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound);
+                let rank = self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound);
                 if rank == 0 {
                     // No elements before this bound, return empty range
                     return (1, 0);
@@ -2745,10 +2716,8 @@ where
     where
         R: RangeBounds<usize>,
     {
-        let (
-            (global_front_idx, front_node_idx, front_start_idx),
-            (global_back_idx, back_node_idx, back_start_idx),
-        ) = self.set.resolve_range(range);
+        let ((global_front_idx, front_node_idx, front_start_idx), (global_back_idx, back_node_idx, back_start_idx)) =
+            self.set.resolve_range(range);
         let end = self.set.inner[back_node_idx].len();
 
         let mut inner = self.set.inner.iter_mut();
@@ -2937,9 +2906,7 @@ where
         Q: Ord,
     {
         BTreeMap {
-            set: self
-                .set
-                .split_off_cmp(|item: &Pair<K, V>| item.key.borrow() < key),
+            set: self.set.split_off_cmp(|item: &Pair<K, V>| item.key.borrow() < key),
         }
     }
     /// Gets an iterator over the values of the map, in order by key.
@@ -2959,9 +2926,7 @@ where
     /// assert_eq!(values, ["hello", "goodbye"]);
     /// ```
     pub fn values(&self) -> Values<K, V> {
-        Values {
-            inner: self.set.iter(),
-        }
+        Values { inner: self.set.iter() }
     }
     /// Gets a mutable iterator over the values of the map, in order by key.
     ///
@@ -2985,9 +2950,7 @@ where
     ///                     String::from("goodbye!")]);
     /// ```
     pub fn values_mut(&mut self) -> ValuesMut<K, V> {
-        ValuesMut {
-            inner: self.iter_mut(),
-        }
+        ValuesMut { inner: self.iter_mut() }
     }
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
     ///
@@ -3113,14 +3076,8 @@ where
         Q: Ord,
     {
         let start_idx = match bound {
-            Bound::Included(start) => self
-                .set
-                .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < start),
-            Bound::Excluded(start) => {
-                self.set
-                    .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < start)
-                    + 1
-            }
+            Bound::Included(start) => self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < start),
+            Bound::Excluded(start) => self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < start) + 1,
             Bound::Unbounded => 0,
         };
 
@@ -3154,8 +3111,7 @@ where
         Q: Ord + ?Sized,
         K: Borrow<Q>,
     {
-        self.set
-            .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < value)
+        self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < value)
     }
 }
 
@@ -3197,9 +3153,7 @@ where
     type IntoIter = IterMap<'a, K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
-        IterMap {
-            inner: self.set.iter(),
-        }
+        IterMap { inner: self.set.iter() }
     }
 }
 
@@ -3581,8 +3535,9 @@ where
                 return None;
             }
             // Handle single node case or adjacent nodes
-            if self.current_front_node_idx == self.current_back_node_idx ||
-               self.current_front_node_idx == self.current_back_node_idx - 1 {
+            if self.current_front_node_idx == self.current_back_node_idx
+                || self.current_front_node_idx == self.current_back_node_idx - 1
+            {
                 // take from the current front iter
                 if let Some(entry) = self.current_front_iterator.next_back() {
                     if self.current_back_idx > 0 {
@@ -3822,13 +3777,12 @@ mod tests {
 
         let expected_output: Vec<isize> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-        let actual_node =
-            input
-                .iter()
-                .fold(Node::with_capacity(DEFAULT_INNER_SIZE), |mut acc, curr| {
-                    NodeLike::insert(&mut acc, *curr);
-                    acc
-                });
+        let actual_node = input
+            .iter()
+            .fold(Node::with_capacity(DEFAULT_INNER_SIZE), |mut acc, curr| {
+                NodeLike::insert(&mut acc, *curr);
+                acc
+            });
 
         let actual_output: Vec<isize> = actual_node.iter().cloned().collect();
 
@@ -3950,10 +3904,7 @@ mod tests {
         btree.iter().for_each(|item| {
             if *item < DEFAULT_INNER_SIZE {
                 assert_eq!(front_spine.get_index(0), front_spine.first());
-                assert_eq!(
-                    front_spine.pop_first().unwrap() + 1,
-                    *front_spine.first().unwrap()
-                );
+                assert_eq!(front_spine.pop_first().unwrap() + 1, *front_spine.first().unwrap());
             } else {
                 assert_eq!(front_spine.pop_first().unwrap(), DEFAULT_INNER_SIZE);
                 assert_eq!(front_spine.first(), None);
@@ -3962,14 +3913,8 @@ mod tests {
 
         input.iter().rev().for_each(|item| {
             if *item > 0 {
-                assert_eq!(
-                    back_spine.get_index(back_spine.len() - 1),
-                    back_spine.last()
-                );
-                assert_eq!(
-                    back_spine.pop_last().unwrap() - 1,
-                    *back_spine.last().unwrap()
-                );
+                assert_eq!(back_spine.get_index(back_spine.len() - 1), back_spine.last());
+                assert_eq!(back_spine.pop_last().unwrap() - 1, *back_spine.last().unwrap());
             } else {
                 assert_eq!(back_spine.pop_last(), Some(0));
                 assert_eq!(back_spine.last(), None);
@@ -4000,10 +3945,7 @@ mod tests {
 
         expected_output.into_iter().for_each(|item| {
             assert_eq!(*btree.get_index(item).unwrap(), item);
-            assert_eq!(
-                *btree.get_index(item).unwrap(),
-                *btree.lower_bound(&item).unwrap()
-            );
+            assert_eq!(*btree.get_index(item).unwrap(), *btree.lower_bound(&item).unwrap());
             assert!(btree.contains(&item));
         });
     }
@@ -4025,14 +3967,10 @@ mod tests {
         let btree = BTreeMap::from_iter((0..(DEFAULT_INNER_SIZE * 10)).enumerate().rev());
         assert_eq!(btree.set.inner.len(), 19);
         let expected_forward = Vec::from_iter((0..(DEFAULT_INNER_SIZE * 10)).enumerate());
-        btree
-            .clone()
-            .iter_mut()
-            .zip(expected_forward)
-            .for_each(|(lhs, rhs)| {
-                assert_eq!(*lhs.0, rhs.0);
-                assert_eq!(*lhs.1, rhs.1);
-            });
+        btree.clone().iter_mut().zip(expected_forward).for_each(|(lhs, rhs)| {
+            assert_eq!(*lhs.0, rhs.0);
+            assert_eq!(*lhs.1, rhs.1);
+        });
 
         let expected_backward = Vec::from_iter((0..(DEFAULT_INNER_SIZE * 10)).enumerate().rev());
         btree
@@ -4083,26 +4021,11 @@ mod tests {
             Vec::from_iter(btree.range_idx(..10).cloned()),
             Vec::from_iter(btree.iter().cloned())
         );
-        assert_eq!(
-            Vec::from_iter(btree.range_idx(1..2).cloned()),
-            first_to_second
-        );
-        assert_eq!(
-            Vec::from_iter(btree.range_idx(3..10).cloned()),
-            three_til_end
-        );
-        assert_eq!(
-            Vec::from_iter(btree.range_idx(0..4).cloned()),
-            start_til_four
-        );
-        assert_eq!(
-            Vec::from_iter(btree.range_idx(0..10).cloned()),
-            start_til_end
-        );
-        assert_eq!(
-            Vec::from_iter(btree.range_idx(5..=6).cloned()),
-            five_til_six_included
-        );
+        assert_eq!(Vec::from_iter(btree.range_idx(1..2).cloned()), first_to_second);
+        assert_eq!(Vec::from_iter(btree.range_idx(3..10).cloned()), three_til_end);
+        assert_eq!(Vec::from_iter(btree.range_idx(0..4).cloned()), start_til_four);
+        assert_eq!(Vec::from_iter(btree.range_idx(0..10).cloned()), start_til_end);
+        assert_eq!(Vec::from_iter(btree.range_idx(5..=6).cloned()), five_til_six_included);
         assert_eq!(
             Vec::from_iter(btree.range_idx(0..=7).cloned()),
             start_til_seven_included
@@ -4195,9 +4118,7 @@ mod tests {
     #[test]
     fn test_non_boolean_set_operations() {
         let left_spine = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 1)).into_iter());
-        let right_spine = BTreeSet::from_iter(
-            ((DEFAULT_INNER_SIZE - 1)..((DEFAULT_INNER_SIZE + 1) * 2)).into_iter(),
-        );
+        let right_spine = BTreeSet::from_iter(((DEFAULT_INNER_SIZE - 1)..((DEFAULT_INNER_SIZE + 1) * 2)).into_iter());
 
         let mut union = left_spine.clone();
         let mut temp_right_spine = right_spine.clone();
@@ -4215,14 +4136,8 @@ mod tests {
         let left_diff = Vec::from_iter(0..(DEFAULT_INNER_SIZE - 1));
         let right_diff = Vec::from_iter((DEFAULT_INNER_SIZE + 1)..((DEFAULT_INNER_SIZE + 1) * 2));
 
-        assert_eq!(
-            left_diff,
-            Vec::from_iter(left_spine.difference(&right_spine).cloned())
-        );
-        assert_eq!(
-            right_diff,
-            Vec::from_iter(right_spine.difference(&left_spine).cloned())
-        );
+        assert_eq!(left_diff, Vec::from_iter(left_spine.difference(&right_spine).cloned()));
+        assert_eq!(right_diff, Vec::from_iter(right_spine.difference(&left_spine).cloned()));
 
         let intersection = vec![DEFAULT_INNER_SIZE - 1, DEFAULT_INNER_SIZE];
         assert_eq!(
@@ -4248,8 +4163,7 @@ mod tests {
         assert!(empty_set.is_empty());
         let a = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 1)).into_iter());
         let b = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 2)).into_iter());
-        let c =
-            BTreeSet::from_iter(((DEFAULT_INNER_SIZE + 2)..(DEFAULT_INNER_SIZE + 4)).into_iter());
+        let c = BTreeSet::from_iter(((DEFAULT_INNER_SIZE + 2)..(DEFAULT_INNER_SIZE + 4)).into_iter());
 
         assert!(a.is_subset(&a));
         assert!(a.is_superset(&a));
@@ -4290,12 +4204,7 @@ mod tests {
         let btree: BTreeSet<usize> = BTreeSet::from_iter(0..10);
         assert_eq!(btree.range((Included(5), Included(10))).count(), 5);
         assert_eq!(btree.range((Included(5), Included(11))).count(), 5);
-        assert_eq!(
-            btree
-                .range((Included(5), Included(10 + DEFAULT_INNER_SIZE)))
-                .count(),
-            5
-        );
+        assert_eq!(btree.range((Included(5), Included(10 + DEFAULT_INNER_SIZE))).count(), 5);
         assert_eq!(btree.range((Included(0), Included(11))).count(), 10);
     }
 
@@ -4316,10 +4225,7 @@ mod tests {
             (0..=DEFAULT_INNER_SIZE + 1).count()
         );
 
-        assert_eq!(
-            btree.iter().rev().count(),
-            (0..(DEFAULT_INNER_SIZE + 10)).count()
-        );
+        assert_eq!(btree.iter().rev().count(), (0..(DEFAULT_INNER_SIZE + 10)).count());
         assert_eq!(
             btree.range(0..DEFAULT_INNER_SIZE).rev().count(),
             (0..DEFAULT_INNER_SIZE).count()
@@ -4351,12 +4257,7 @@ mod tests {
         assert_eq!(btree.range(..1).rev().count(), 0);
 
         assert_eq!(btree.range(..DEFAULT_INNER_SIZE).count(), 0);
-        assert_eq!(
-            btree
-                .range(DEFAULT_INNER_SIZE..DEFAULT_INNER_SIZE * 2)
-                .count(),
-            0
-        );
+        assert_eq!(btree.range(DEFAULT_INNER_SIZE..DEFAULT_INNER_SIZE * 2).count(), 0);
     }
 
     #[test]
@@ -4418,7 +4319,7 @@ mod tests {
         let expected_backward = vec![(3, 30), (2, 20), (1, 10)];
         for (i, (k, v)) in map.iter_mut().rev().enumerate() {
             assert_eq!(*k, expected_backward[i].0);
-            assert_eq!(*v, expected_backward[i].1); 
+            assert_eq!(*v, expected_backward[i].1);
         }
     }
 
@@ -4426,19 +4327,19 @@ mod tests {
     fn test_indexset_btreemap_overflow_bug() {
         // This test reproduces the "attempt to subtract with overflow" panic
         // that occurs in indexset::BTreeMap::range_to_idx at line 2639
-        
+
         let mut map = BTreeMap::new();
-        
+
         // Insert the same keys as in the failing test
         map.insert(vec![1, 2, 3, 4], 1);
         map.insert(vec![1, 2, 3, 7], 2);
         map.insert(vec![1, 2, 4, 5], 3);
         let end_key = vec![1, 2, 3, 4];
-        
+
         let mut range_iter = map.range(..end_key).rev();
-        
+
         let result = range_iter.next();
-        
+
         // In a working implementation, this should return None
         // since there are no keys before [1,2,3,4]
         assert!(result.is_none(), "Expected None when ranging before first key");
@@ -4471,10 +4372,16 @@ mod tests {
         // RangeFromExcluding with non-existing key [1,2,3,6]
         // Should return [1,2,3,7] but returns [1,2,4,5]
         let non_existing_key = vec![1, 2, 3, 6];
-        let range = RangeFromExcluding { from: &non_existing_key };
+        let range = RangeFromExcluding {
+            from: &non_existing_key,
+        };
         let result = map.range(range).next().unwrap();
-        
-        assert_eq!(result.0, &vec![1, 2, 3, 7], "RangeFromExcluding skips entries incorrectly");
+
+        assert_eq!(
+            result.0,
+            &vec![1, 2, 3, 7],
+            "RangeFromExcluding skips entries incorrectly"
+        );
         assert_eq!(*result.1, 2);
     }
 


### PR DESCRIPTION
This PR just adds `.rustfmt.toml` that allows to have per-project fmt setting so automated cargo-fmt runs will not clobber git diff.

Also `cargo fmt` was applied after file addition.

You can change values anyhow you want, I just propose to add this setting file to have source of truth for `cargo fmt` settings