### PR TITLE
Fix flaky tests (with some bugfix also)

### DIFF
--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -480,6 +480,31 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_split_insert_replaces_left_split_max() {
+        let maximum_node_size = 4;
+        let map = BTreeMap::<usize, &str>::with_maximum_node_size(maximum_node_size);
+
+        for key in 0..maximum_node_size {
+            assert_eq!(map.insert(key, "old"), None);
+        }
+
+        let split_left_max = maximum_node_size / 2 - 1;
+
+        assert_eq!(map.insert(split_left_max, "new"), Some("old"));
+        assert_eq!(map.len(), maximum_node_size);
+        assert_eq!(
+            map.get(&split_left_max).map(|entry| entry.get().value),
+            Some("new")
+        );
+        assert_eq!(
+            map.iter()
+                .filter(|(key, _)| **key == split_left_max)
+                .count(),
+            1
+        );
+    }
+
     #[derive(Debug, Default)]
     struct PersistedBTreeMap<K, V>
     where

--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -522,11 +522,19 @@ mod tests {
                 ChangeEvent::RemoveAt {
                     max_value,
                     index,
-                    value: _,
+                    value,
                     event_id: _,
                 } => {
+                    let mut max_removed = false;
                     if let Some(node) = self.nodes.get_mut(&max_value.key) {
                         node.remove(*index);
+                        max_removed = max_value.key == value.key;
+                    }
+                    if max_removed {
+                        let node = self.nodes.remove(&max_value.key).unwrap();
+                        if let Some(new_max) = node.last() {
+                            self.nodes.insert(new_max.key.clone(), node);
+                        }
                     }
                 }
                 ChangeEvent::SplitNode {

--- a/src/concurrent/operation.rs
+++ b/src/concurrent/operation.rs
@@ -51,7 +51,7 @@ where
                         let mut old_value: Option<T> = None;
                         let mut insert_attempted = false;
                         if let Some(max) = guard.max().cloned() {
-                            if max > value {
+                            if max >= value {
                                 let (inserted, idx) = NodeLike::insert(&mut *guard, value.clone());
                                 insert_attempted = true;
                                 if !inserted {

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -153,7 +153,7 @@ where
                         let first_node = Arc::new(Mutex::new(first_node));
 
                         drop(_global_guard);
-                        if let Ok(_) = self.index_lock.try_write() {
+                        if let Ok(_write_guard) = self.index_lock.try_write() {
                             #[cfg(feature = "cdc")]
                             {
                                 let node_insertion = ChangeEvent::CreateNode {
@@ -231,8 +231,7 @@ where
                         #[cfg(feature = "cdc")]
                         {
                             for unassigned_event in value_cdc {
-                                let event_id =
-                                    self.event_id.fetch_add(1, Ordering::AcqRel).into();
+                                let event_id = self.event_id.fetch_add(1, Ordering::AcqRel).into();
                                 cdc.push(unassigned_event.assign_id(event_id));
                             }
                         }
@@ -246,8 +245,7 @@ where
                         #[cfg(feature = "cdc")]
                         {
                             for unassigned_event in value_cdc {
-                                let event_id =
-                                    self.event_id.fetch_add(1, Ordering::AcqRel).into();
+                                let event_id = self.event_id.fetch_add(1, Ordering::AcqRel).into();
                                 cdc.push(unassigned_event.assign_id(event_id));
                             }
                         }
@@ -365,9 +363,7 @@ where
         loop {
             let mut cdc = vec![];
             let _global_guard = self.index_lock.read();
-            if let Some(target_node_entry) =
-                self.index.lower_bound(Bound::Included(&value))
-            {
+            if let Some(target_node_entry) = self.index.lower_bound(Bound::Included(&value)) {
                 let mut node_guard = target_node_entry.value().lock_arc();
                 let old_max = node_guard.max().cloned();
                 let deleted = NodeLike::delete(&mut *node_guard, value);
@@ -1962,7 +1958,7 @@ mod tests {
         }
 
         let set_clone = Arc::clone(&set);
-        let _ = thread::spawn(move || {
+        let handle = thread::spawn(move || {
             for _ in 0..1000 {
                 let mut _sum = 0;
                 for &value in set_clone.iter() {
@@ -1974,5 +1970,6 @@ mod tests {
         for i in 10_000..20_000 {
             set.insert(i);
         }
+        handle.join().unwrap();
     }
 }

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -231,7 +231,8 @@ where
                         #[cfg(feature = "cdc")]
                         {
                             for unassigned_event in value_cdc {
-                                let event_id = self.event_id.fetch_add(1, Ordering::AcqRel).into();
+                                let event_id =
+                                    self.event_id.fetch_add(1, Ordering::AcqRel).into();
                                 cdc.push(unassigned_event.assign_id(event_id));
                             }
                         }
@@ -245,7 +246,8 @@ where
                         #[cfg(feature = "cdc")]
                         {
                             for unassigned_event in value_cdc {
-                                let event_id = self.event_id.fetch_add(1, Ordering::AcqRel).into();
+                                let event_id =
+                                    self.event_id.fetch_add(1, Ordering::AcqRel).into();
                                 cdc.push(unassigned_event.assign_id(event_id));
                             }
                         }
@@ -363,7 +365,9 @@ where
         loop {
             let mut cdc = vec![];
             let _global_guard = self.index_lock.read();
-            if let Some(target_node_entry) = self.index.lower_bound(Bound::Included(&value)) {
+            if let Some(target_node_entry) =
+                self.index.lower_bound(Bound::Included(&value))
+            {
                 let mut node_guard = target_node_entry.value().lock_arc();
                 let old_max = node_guard.max().cloned();
                 let deleted = NodeLike::delete(&mut *node_guard, value);


### PR DESCRIPTION
When running tests I sometimes saw some of them were flaky, so I checked them more closely.

1.  For `Split` operation one statement was changed to avoid situation when "replace" insert scenario on full node may cause pair duplication (appeared both in right and left parts of split node). `test_split_insert_replaces_left_split_max` shows this situation and covers behaviour
2. Fix of `PersistedBTreeMap` in test which was incorrectly behaving on node max value removal (it was not updating map with new max)
3. Dropped `_write_guard` which caused concurrency issues.