### PR TITLE
Add support for `MultiPair` customization

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2024"
+max_width = 120

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ harness = false
 [[bench]]
 name = "concurrent"
 harness = false
+required-features = ["multimap"]

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -111,7 +111,8 @@ fn bench_btreeset_with_ratio(c: &mut Criterion, write_ratio: f64) {
 
     group.bench_function(BenchmarkId::new("ConcurrentBTreeSet", write_ratio), |b| {
         b.iter(|| {
-            let set: Arc<indexset::concurrent::set::BTreeSet<usize>> = Arc::new(indexset::concurrent::set::BTreeSet::new());
+            let set: Arc<indexset::concurrent::set::BTreeSet<usize>> =
+                Arc::new(indexset::concurrent::set::BTreeSet::new());
             let mut handles = vec![];
 
             for thread_ops in operations.iter() {

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -1,7 +1,10 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use crossbeam_skiplist::SkipSet;
-use rand::{thread_rng, Rng};
+use indexset::concurrent::multimap::BTreeMultiMap;
+use indexset::core::multipair::OrdMultiPair;
+use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
 use scc::TreeIndex;
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::thread;
 
@@ -16,6 +19,8 @@ const NUM_WRITERS: usize = 10;
 const NUM_THREADS: usize = NUM_READERS + NUM_WRITERS;
 const OPERATIONS_PER_THREAD: usize = 100_000;
 const TOTAL_OPERATIONS: usize = NUM_THREADS * OPERATIONS_PER_THREAD;
+const MULTIMAP_REMOVE_ENTRIES: usize = 20_000;
+const MULTIMAP_REMOVE_SEED: u64 = 42;
 
 // fn generate_operations(write_ratio: f64) -> Vec<Vec<Op>> {
 //     let mut rng = thread_rng();
@@ -177,5 +182,94 @@ fn bench_concurrent_btreeset(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_concurrent_btreeset);
+fn removal_entries(values_per_key: RangeInclusive<usize>) -> Vec<(usize, usize)> {
+    let mut rng = StdRng::seed_from_u64(MULTIMAP_REMOVE_SEED);
+    let mut entries = Vec::with_capacity(MULTIMAP_REMOVE_ENTRIES);
+    let mut key = 0;
+
+    while entries.len() < MULTIMAP_REMOVE_ENTRIES {
+        let value_count = rng.random_range(values_per_key.clone());
+        entries.extend((0..value_count).map(|value| (key, value)));
+        key += 1;
+    }
+
+    entries
+}
+
+fn build_random_multimap(entries: &[(usize, usize)]) -> BTreeMultiMap<usize, usize> {
+    let map = BTreeMultiMap::<usize, usize>::new();
+    for (key, value) in entries {
+        map.insert(*key, *value);
+    }
+
+    map
+}
+
+fn build_ord_multimap(
+    entries: &[(usize, usize)],
+) -> BTreeMultiMap<
+    usize,
+    usize,
+    Vec<OrdMultiPair<usize, usize>>,
+    OrdMultiPair<usize, usize>,
+> {
+    let map = BTreeMultiMap::<
+        usize,
+        usize,
+        Vec<OrdMultiPair<usize, usize>>,
+        OrdMultiPair<usize, usize>,
+    >::new();
+    for (key, value) in entries {
+        map.insert(*key, *value);
+    }
+
+    map
+}
+
+fn bench_multimap_removal(c: &mut Criterion) {
+    let usual_entries = removal_entries(1..=3);
+    let many_entries = removal_entries(1_000..=2_000);
+    let usual_target = *usual_entries.last().unwrap();
+    let many_target = *many_entries.last().unwrap();
+
+    let mut group = c.benchmark_group("BTreeMultiMap remove pair");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+    group.measurement_time(std::time::Duration::from_millis(500));
+
+    group.bench_function(BenchmarkId::new("random", "1-3 values per key"), |b| {
+        b.iter_batched_ref(
+            || build_random_multimap(&usual_entries),
+            |map| black_box(map.remove(&usual_target.0, &usual_target.1)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function(BenchmarkId::new("ord", "1-3 values per key"), |b| {
+        b.iter_batched_ref(
+            || build_ord_multimap(&usual_entries),
+            |map| black_box(map.remove(&usual_target.0, &usual_target.1)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function(BenchmarkId::new("random", "1000-2000 values per key"), |b| {
+        b.iter_batched_ref(
+            || build_random_multimap(&many_entries),
+            |map| black_box(map.remove(&many_target.0, &many_target.1)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function(BenchmarkId::new("ord", "1000-2000 values per key"), |b| {
+        b.iter_batched_ref(
+            || build_ord_multimap(&many_entries),
+            |map| black_box(map.remove(&many_target.0, &many_target.1)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_concurrent_btreeset, bench_multimap_removal);
 criterion_main!(benches);

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use crossbeam_skiplist::SkipSet;
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use scc::TreeIndex;
 use std::sync::Arc;
 use std::thread;
@@ -37,21 +37,23 @@ const TOTAL_OPERATIONS: usize = NUM_THREADS * OPERATIONS_PER_THREAD;
 // }
 
 fn generate_operations(write_ratio: f64) -> Vec<Vec<Op>> {
-    let mut rng = thread_rng();
-    let mut all_operations = vec![Vec::with_capacity(OPERATIONS_PER_THREAD); NUM_THREADS];
+    let mut rng = rng();
+    let mut all_operations: Vec<Vec<Op>> = (0..NUM_THREADS)
+        .map(|_| Vec::with_capacity(OPERATIONS_PER_THREAD))
+        .collect();
 
-    for thread_idx in 0..NUM_THREADS {
+    for (thread_idx, operations) in all_operations.iter_mut().enumerate() {
         let range_start = thread_idx * (TOTAL_OPERATIONS / NUM_THREADS);
         let range_end = (thread_idx + 1) * (TOTAL_OPERATIONS / NUM_THREADS);
 
         for _ in 0..OPERATIONS_PER_THREAD {
-            let value = rng.gen_range(range_start..range_end);
-            let operation = if thread_idx < NUM_WRITERS || rng.gen::<f64>() < write_ratio {
+            let value = rng.random_range(range_start..range_end);
+            let operation = if thread_idx < NUM_WRITERS || rng.random::<f64>() < write_ratio {
                 Op::Write(value)
             } else {
                 Op::Read(value)
             };
-            all_operations[thread_idx].push(operation);
+            operations.push(operation);
         }
     }
     all_operations
@@ -94,9 +96,8 @@ fn bench_btreeset_with_ratio(c: &mut Criterion, write_ratio: f64) {
                             black_box(set.contains(&item));
                         },
                         |set, item| {
-                            black_box({
-                                let _ = set.insert(item, ());
-                            });
+                            let _ = set.insert(item, ());
+                            black_box(());
                         },
                     );
                 });

--- a/benches/stdlib.rs
+++ b/benches/stdlib.rs
@@ -1,13 +1,13 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use rand::rng;
 use rand::seq::SliceRandom;
-use rand::thread_rng;
 use scc::TreeIndex;
 use std::hint::black_box;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let n = 100000;
     let mut input: Vec<usize> = (0..n).collect();
-    input.shuffle(&mut thread_rng());
+    input.shuffle(&mut rng());
 
     c.bench_function("stdlib insert 100k", |b| {
         b.iter(|| {
@@ -47,7 +47,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             let treeindex = TreeIndex::new();
 
             input.iter().for_each(|item| {
-                black_box(treeindex.insert(*item, ()).unwrap());
+                let _: () = treeindex.insert(*item, ()).unwrap();
+                black_box(());
             });
 
             assert_eq!(treeindex.len(), n);

--- a/src/cdc/change.rs
+++ b/src/cdc/change.rs
@@ -1,8 +1,5 @@
 #[cfg(feature = "multimap")]
-use {
-    crate::core::multipair::MultiPair,
-    crate::core::pair::Pair,
-};
+use {crate::core::multipair::MultiPair, crate::core::pair::Pair};
 
 /// Unique event identifier.
 ///
@@ -96,43 +93,36 @@ impl<T> ChangeEvent<T> {
 #[derive(Debug, Clone)]
 pub enum ChangeEventUnassigned<T> {
     /// Unassigned [`ChangeEvent::InsertAt`].
-    InsertAt {
-        max_value: T,
-        value: T,
-        index: usize,
-    },
+    InsertAt { max_value: T, value: T, index: usize },
     /// Unassigned [`ChangeEvent::RemoveAt`].
-    RemoveAt {
-        max_value: T,
-        value: T,
-        index: usize,
-    },
+    RemoveAt { max_value: T, value: T, index: usize },
     /// Unassigned [`ChangeEvent::CreateNode`].
-    CreateNode {
-        max_value: T,
-    },
+    CreateNode { max_value: T },
     /// Unassigned [`ChangeEvent::RemoveNode`].
-    RemoveNode {
-        max_value: T,
-    },
+    RemoveNode { max_value: T },
     /// Unassigned [`ChangeEvent::SplitNode`].
-    SplitNode {
-        max_value: T,
-        split_index: usize,
-    },
+    SplitNode { max_value: T, split_index: usize },
 }
 
 impl<T> ChangeEventUnassigned<T> {
     /// Assign an event [`Id`] to this unassigned event, converting it to a [`ChangeEvent`].
     pub fn assign_id(self, event_id: Id) -> ChangeEvent<T> {
         match self {
-            Self::InsertAt { max_value, value, index } => ChangeEvent::InsertAt {
+            Self::InsertAt {
+                max_value,
+                value,
+                index,
+            } => ChangeEvent::InsertAt {
                 event_id,
                 max_value,
                 value,
                 index,
             },
-            Self::RemoveAt { max_value, value, index } => ChangeEvent::RemoveAt {
+            Self::RemoveAt {
+                max_value,
+                value,
+                index,
+            } => ChangeEvent::RemoveAt {
                 event_id,
                 max_value,
                 value,
@@ -140,13 +130,14 @@ impl<T> ChangeEventUnassigned<T> {
             },
             Self::CreateNode { max_value } => ChangeEvent::CreateNode { event_id, max_value },
             Self::RemoveNode { max_value } => ChangeEvent::RemoveNode { event_id, max_value },
-            Self::SplitNode { max_value, split_index } => {
-                ChangeEvent::SplitNode { event_id, max_value, split_index }
-            }
+            Self::SplitNode { max_value, split_index } => ChangeEvent::SplitNode {
+                event_id,
+                max_value,
+                split_index,
+            },
         }
     }
 }
-
 
 #[cfg(feature = "multimap")]
 impl<K: Ord, V: PartialEq> From<ChangeEvent<MultiPair<K, V>>> for ChangeEvent<Pair<K, V>> {

--- a/src/cdc/change.rs
+++ b/src/cdc/change.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "multimap")]
 use {
-    crate::core::multipair::MultiPair,
+    crate::core::multipair::{OrdMultiPair, RandomMultiPair},
     crate::core::pair::Pair,
 };
 
@@ -149,48 +149,63 @@ impl<T> ChangeEventUnassigned<T> {
 
 
 #[cfg(feature = "multimap")]
-impl<K: Ord, V: PartialEq> From<ChangeEvent<MultiPair<K, V>>> for ChangeEvent<Pair<K, V>> {
-    fn from(ev: ChangeEvent<MultiPair<K, V>>) -> Self {
-        match ev {
-            ChangeEvent::InsertAt {
-                event_id,
-                max_value,
-                value,
-                index,
-            } => ChangeEvent::InsertAt {
-                event_id,
-                max_value: max_value.into(),
-                value: value.into(),
-                index,
-            },
-            ChangeEvent::RemoveAt {
-                event_id,
-                max_value,
-                value,
-                index,
-            } => ChangeEvent::RemoveAt {
-                event_id,
-                max_value: max_value.into(),
-                value: value.into(),
-                index,
-            },
-            ChangeEvent::CreateNode { event_id, max_value } => ChangeEvent::CreateNode {
-                event_id,
-                max_value: max_value.into(),
-            },
-            ChangeEvent::RemoveNode { event_id, max_value } => ChangeEvent::RemoveNode {
-                event_id,
-                max_value: max_value.into(),
-            },
-            ChangeEvent::SplitNode {
-                event_id,
-                max_value,
-                split_index,
-            } => ChangeEvent::SplitNode {
-                event_id,
-                max_value: max_value.into(),
-                split_index,
-            },
-        }
+fn multipair_change_event_into_pair<K, V, M>(ev: ChangeEvent<M>) -> ChangeEvent<Pair<K, V>>
+where
+    M: Into<Pair<K, V>>,
+{
+    match ev {
+        ChangeEvent::InsertAt {
+            event_id,
+            max_value,
+            value,
+            index,
+        } => ChangeEvent::InsertAt {
+            event_id,
+            max_value: max_value.into(),
+            value: value.into(),
+            index,
+        },
+        ChangeEvent::RemoveAt {
+            event_id,
+            max_value,
+            value,
+            index,
+        } => ChangeEvent::RemoveAt {
+            event_id,
+            max_value: max_value.into(),
+            value: value.into(),
+            index,
+        },
+        ChangeEvent::CreateNode { event_id, max_value } => ChangeEvent::CreateNode {
+            event_id,
+            max_value: max_value.into(),
+        },
+        ChangeEvent::RemoveNode { event_id, max_value } => ChangeEvent::RemoveNode {
+            event_id,
+            max_value: max_value.into(),
+        },
+        ChangeEvent::SplitNode {
+            event_id,
+            max_value,
+            split_index,
+        } => ChangeEvent::SplitNode {
+            event_id,
+            max_value: max_value.into(),
+            split_index,
+        },
+    }
+}
+
+#[cfg(feature = "multimap")]
+impl<K, V> From<ChangeEvent<RandomMultiPair<K, V>>> for ChangeEvent<Pair<K, V>> {
+    fn from(ev: ChangeEvent<RandomMultiPair<K, V>>) -> Self {
+        multipair_change_event_into_pair(ev)
+    }
+}
+
+#[cfg(feature = "multimap")]
+impl<K, V> From<ChangeEvent<OrdMultiPair<K, V>>> for ChangeEvent<Pair<K, V>> {
+    fn from(ev: ChangeEvent<OrdMultiPair<K, V>>) -> Self {
+        multipair_change_event_into_pair(ev)
     }
 }

--- a/src/concurrent.rs
+++ b/src/concurrent.rs
@@ -1,7 +1,7 @@
 pub mod map;
-pub mod set;
-pub(crate) mod r#ref;
 pub(crate) mod operation;
+pub(crate) mod r#ref;
+pub mod set;
 
 #[cfg(feature = "multimap")]
 pub mod multimap;

--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -253,10 +253,7 @@ where
     pub fn insert(&self, key: K, value: V) -> Option<V> {
         let new_entry = Pair { key, value };
 
-        self.set
-            .put_cdc(new_entry)
-            .0
-            .and_then(|pair| Some(pair.value))
+        self.set.put_cdc(new_entry).0.and_then(|pair| Some(pair.value))
     }
     pub fn checked_insert(&self, key: K, value: V) -> Option<()> {
         let new_entry = Pair { key, value };
@@ -299,9 +296,7 @@ where
         Pair<K, V>: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        self.set
-            .remove(key)
-            .and_then(|pair| Some((pair.key, pair.value)))
+        self.set.remove(key).and_then(|pair| Some((pair.key, pair.value)))
     }
     /// Removes a key from the map, returning the key and the value if the key
     /// was previously in the map and [`ChangeEvent`]s describing changes caused
@@ -397,9 +392,7 @@ where
     /// assert_eq!((*first_key, *first_value), (1, "a"));
     /// ```
     pub fn iter(&self) -> Iter<'_, K, V, Node> {
-        Iter {
-            inner: self.set.iter(),
-        }
+        Iter { inner: self.set.iter() }
     }
     /// Constructs a double-ended iterator over a sub-range of elements in the map.
     /// The simplest way is to use the range syntax `min..max`, thus `range(min..max)` will
@@ -447,13 +440,13 @@ mod tests {
     use super::BTreeMap;
     use super::ChangeEvent;
     use super::Pair;
+    use crate::core::constants::DEFAULT_INNER_SIZE;
     use crate::BTreeSet;
     use rand::Rng;
     use scc::HashMap;
     use std::fmt::Debug;
     use std::sync::{Arc, Mutex};
     use std::thread;
-    use crate::core::constants::DEFAULT_INNER_SIZE;
 
     #[test]
     fn test_range_edge_cast() {
@@ -492,17 +485,11 @@ mod tests {
     impl<K: Debug + Ord + Clone, V: Debug + Clone + PartialEq> PersistedBTreeMap<K, V> {
         fn persist(&mut self, event: &ChangeEvent<Pair<K, V>>) {
             match event {
-                ChangeEvent::CreateNode {
-                    max_value,
-                    event_id: _,
-                } => {
+                ChangeEvent::CreateNode { max_value, event_id: _ } => {
                     let node = vec![max_value.clone()];
                     self.nodes.insert(max_value.key.clone(), node);
                 }
-                ChangeEvent::RemoveNode {
-                    max_value,
-                    event_id: _,
-                } => {
+                ChangeEvent::RemoveNode { max_value, event_id: _ } => {
                     self.nodes.remove(&max_value.key);
                 }
                 ChangeEvent::InsertAt {
@@ -741,13 +728,13 @@ mod tests {
             .collect::<_>();
         assert_eq!(mock_state.nodes, expected_state);
     }
-    
+
     #[cfg(feature = "cdc")]
     #[test]
     fn test_cdc_event_ids_sequential_no_gaps() {
         let map = BTreeMap::<usize, String>::new();
         let mut all_events = Vec::new();
-        
+
         for i in 0..100 {
             let (_, events) = map.insert_cdc(i, format!("val{}", i));
             all_events.extend(events);
@@ -768,23 +755,23 @@ mod tests {
             );
         }
     }
-    
+
     #[cfg(feature = "cdc")]
     #[test]
     fn test_cdc_remove_monotonicity() {
         let map = BTreeMap::<usize, String>::new();
         let mut all_events = Vec::new();
-        
+
         for i in 0..50 {
             let (_, events) = map.insert_cdc(i, format!("val{}", i));
             all_events.extend(events);
         }
-        
+
         for i in 0..25 {
             let (_, events) = map.remove_cdc(&i);
             all_events.extend(events);
         }
-        
+
         all_events.sort_by_key(|e| e.id());
 
         // Verify IDs are consecutive with no gaps
@@ -799,21 +786,21 @@ mod tests {
             );
         }
     }
-    
+
     #[cfg(feature = "cdc")]
     #[test]
     fn test_cdc_split_no_gaps() {
         let map = BTreeMap::<usize, String>::new();
         let mut all_events = Vec::new();
-        
+
         let n = DEFAULT_INNER_SIZE + 200;
         for i in 0..n {
             let (_, events) = map.insert_cdc(i, format!("val{}", i));
             all_events.extend(events);
         }
-        
+
         all_events.sort_by_key(|e| e.id());
-        
+
         assert!(!all_events.is_empty(), "Should have at least one event");
         for i in 1..all_events.len() {
             let prev_id = all_events[i - 1].id().inner();
@@ -830,12 +817,9 @@ mod tests {
             .iter()
             .filter(|e| matches!(e, ChangeEvent::SplitNode { .. }))
             .collect();
-        assert!(
-            !split_events.is_empty(),
-            "Should have at least one split event"
-        );
+        assert!(!split_events.is_empty(), "Should have at least one split event");
     }
-    
+
     #[cfg(feature = "cdc")]
     #[test]
     fn test_concurrent_cdc_no_gaps() {
@@ -859,13 +843,13 @@ mod tests {
             });
             handles.push(handle);
         }
-        
+
         let mut final_events = Vec::new();
         for handle in handles {
             let thread_events = handle.join().unwrap();
             final_events.extend(thread_events);
         }
-        
+
         final_events.sort_by_key(|e| e.id());
 
         // Verify no gaps in event IDs
@@ -882,28 +866,28 @@ mod tests {
             );
         }
     }
-    
+
     #[cfg(feature = "cdc")]
     #[test]
     fn test_cdc_mixed_operations() {
         let map = BTreeMap::<usize, String>::new();
         let mut all_events = Vec::new();
-        
+
         for i in 0..100 {
             let (_, events) = map.insert_cdc(i, format!("val{}", i));
             all_events.extend(events);
         }
-        
+
         for i in 0..50 {
             let (_, events) = map.remove_cdc(&i);
             all_events.extend(events);
         }
-        
+
         for i in 100..125 {
             let (_, events) = map.insert_cdc(i, format!("val{}", i));
             all_events.extend(events);
         }
-        
+
         all_events.sort_by_key(|e| e.id());
 
         // Verify IDs are consecutive with no gaps
@@ -911,11 +895,7 @@ mod tests {
         for i in 1..all_events.len() {
             let prev_id = all_events[i - 1].id().inner();
             let curr_id = all_events[i].id().inner();
-            assert_eq!(
-                curr_id,
-                prev_id + 1,
-                "Mixed operation event IDs should be consecutive"
-            );
+            assert_eq!(curr_id, prev_id + 1, "Mixed operation event IDs should be consecutive");
         }
     }
 }

--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -491,6 +491,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_split_insert_replaces_left_split_max() {
+        let maximum_node_size = 4;
+        let map = BTreeMap::<usize, &str>::with_maximum_node_size(maximum_node_size);
+
+        for key in 0..maximum_node_size {
+            assert_eq!(map.insert(key, "old"), None);
+        }
+
+        let split_left_max = maximum_node_size / 2 - 1;
+
+        assert_eq!(map.insert(split_left_max, "new"), Some("old"));
+        assert_eq!(map.len(), maximum_node_size);
+        assert_eq!(map.get(&split_left_max).map(|entry| entry.get().value), Some("new"));
+        assert_eq!(map.iter().filter(|(key, _)| **key == split_left_max).count(), 1);
+    }
+
     #[derive(Debug, Default)]
     struct PersistedBTreeMap<K, V>
     where
@@ -527,11 +544,19 @@ mod tests {
                 ChangeEvent::RemoveAt {
                     max_value,
                     index,
-                    value: _,
+                    value,
                     event_id: _,
                 } => {
+                    let mut max_removed = false;
                     if let Some(node) = self.nodes.get_mut(&max_value.key) {
                         node.remove(*index);
+                        max_removed = max_value.key == value.key;
+                    }
+                    if max_removed {
+                        let node = self.nodes.remove(&max_value.key).unwrap();
+                        if let Some(new_max) = node.last() {
+                            self.nodes.insert(new_max.key.clone(), node);
+                        }
                     }
                 }
                 ChangeEvent::SplitNode {

--- a/src/concurrent/map.rs
+++ b/src/concurrent/map.rs
@@ -253,7 +253,7 @@ where
     pub fn insert(&self, key: K, value: V) -> Option<V> {
         let new_entry = Pair { key, value };
 
-        self.set.put_cdc(new_entry).0.and_then(|pair| Some(pair.value))
+        self.set.put_cdc(new_entry).0.map(|pair| pair.value)
     }
     pub fn checked_insert(&self, key: K, value: V) -> Option<()> {
         let new_entry = Pair { key, value };
@@ -267,7 +267,7 @@ where
 
         let (old_value, cdc) = self.set.put_cdc(new_entry);
 
-        (old_value.and_then(|pair| Some(pair.value)), cdc)
+        (old_value.map(|pair| pair.value), cdc)
     }
     pub fn checked_insert_cdc(&self, key: K, value: V) -> Option<Vec<ChangeEvent<Pair<K, V>>>> {
         let new_entry = Pair { key, value };
@@ -296,11 +296,12 @@ where
         Pair<K, V>: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        self.set.remove(key).and_then(|pair| Some((pair.key, pair.value)))
+        self.set.remove(key).map(|pair| (pair.key, pair.value))
     }
     /// Removes a key from the map, returning the key and the value if the key
     /// was previously in the map and [`ChangeEvent`]s describing changes caused
     /// by this action.
+    #[allow(clippy::type_complexity)]
     pub fn remove_cdc<Q>(&self, key: &Q) -> (Option<(K, V)>, Vec<ChangeEvent<Pair<K, V>>>)
     where
         Pair<K, V>: Borrow<Q> + Ord,
@@ -308,7 +309,7 @@ where
     {
         let (old_value, cdc) = self.set.remove_cdc(key);
 
-        (old_value.and_then(|pair| Some((pair.key, pair.value))), cdc)
+        (old_value.map(|pair| (pair.key, pair.value)), cdc)
     }
     /// Returns the number of elements in the map.
     ///
@@ -326,6 +327,23 @@ where
     /// ```
     pub fn len(&self) -> usize {
         self.set.len()
+    }
+    /// Returns `true` if the map contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use indexset::concurrent::map::BTreeMap;
+    ///
+    /// let mut a = BTreeMap::<usize, &str>::new();
+    /// assert!(a.is_empty());
+    /// a.insert(1, "a");
+    /// assert!(!a.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
     }
     /// Returns the total number of allocated slots across all internal nodes.
     ///
@@ -686,10 +704,10 @@ mod tests {
 
         let expected_values = Arc::new(Mutex::new(HashMap::new()));
 
-        for thread_idx in 0..num_threads {
+        for thread_data in test_data.iter().take(num_threads) {
             let map_clone = Arc::clone(&map);
             let expected_values = Arc::clone(&expected_values);
-            let thread_data = test_data[thread_idx].clone();
+            let thread_data = thread_data.clone();
 
             let handle = thread::spawn(move || {
                 let mut events = Vec::new();
@@ -710,7 +728,7 @@ mod tests {
             let thread_events = handle.join().unwrap();
             final_events.extend(thread_events)
         }
-        final_events.sort_by(|ev1, ev2| ev1.id().cmp(&ev2.id()));
+        final_events.sort_by_key(|event| event.id());
 
         let mut mock_state = PersistedBTreeMap::default();
         for ev in final_events {

--- a/src/concurrent/multimap.rs
+++ b/src/concurrent/multimap.rs
@@ -319,10 +319,7 @@ where
     pub fn insert(&self, key: K, value: V) -> Option<V> {
         let new_entry = MultiPair::new(key, value);
 
-        self.set
-            .put_cdc(new_entry)
-            .0
-            .and_then(|pair| Some(pair.value))
+        self.set.put_cdc(new_entry).0.and_then(|pair| Some(pair.value))
     }
     /// Inserts a key-value pair into the map and returns old value (if it was
     /// already in set) with [`ChangeEvent`]'s that describes this insert
@@ -364,9 +361,7 @@ where
         MultiPair<K, V>: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        self.set
-            .remove(key)
-            .and_then(|pair| Some((pair.key, pair.value)))
+        self.set.remove(key).and_then(|pair| Some((pair.key, pair.value)))
     }
     /// Removes some key from the map that matches the given key, returning the
     /// key and the value if the key was previously in the map with
@@ -419,11 +414,7 @@ where
     /// value if the key was previously in the map with [`ChangeEvent`]'s
     /// describing this `remove_some` action.
     #[cfg(feature = "cdc")]
-    pub fn remove_cdc(
-        &self,
-        key: &K,
-        value: &V,
-    ) -> (Option<(K, V)>, Vec<ChangeEvent<MultiPair<K, V>>>) {
+    pub fn remove_cdc(&self, key: &K, value: &V) -> (Option<(K, V)>, Vec<ChangeEvent<MultiPair<K, V>>>) {
         let discriminant_to_remove = self.raw_get(&key).find(|pair| pair.2 == value);
         if let Some(discriminant_to_remove) = discriminant_to_remove {
             let pair_to_remove = MultiPair {
@@ -520,9 +511,7 @@ where
     /// assert_eq!((*first_key, *first_value), (1, "a"));
     /// ```
     pub fn iter(&self) -> Iter<'_, K, V, Node> {
-        Iter {
-            inner: self.set.iter(),
-        }
+        Iter { inner: self.set.iter() }
     }
     /// Constructs a double-ended iterator over a sub-range of elements in the map.
     /// The simplest way is to use the range syntax `min..max`, thus `range(min..max)` will
@@ -559,22 +548,14 @@ where
     {
         let start_bound = range.start_bound();
         let adjusted_start_bound = match start_bound {
-            std::ops::Bound::Included(start) => {
-                std::ops::Bound::Included(MultiPair::with_infimum(start.clone()))
-            }
-            std::ops::Bound::Excluded(start) => {
-                std::ops::Bound::Excluded(MultiPair::with_supremum(start.clone()))
-            }
+            std::ops::Bound::Included(start) => std::ops::Bound::Included(MultiPair::with_infimum(start.clone())),
+            std::ops::Bound::Excluded(start) => std::ops::Bound::Excluded(MultiPair::with_supremum(start.clone())),
             _ => std::ops::Bound::Unbounded,
         };
         let end_bound = range.end_bound();
         let adjusted_end_bound = match end_bound {
-            std::ops::Bound::Included(end) => {
-                std::ops::Bound::Included(MultiPair::with_supremum(end.clone()))
-            }
-            std::ops::Bound::Excluded(end) => {
-                std::ops::Bound::Excluded(MultiPair::with_infimum(end.clone()))
-            }
+            std::ops::Bound::Included(end) => std::ops::Bound::Included(MultiPair::with_supremum(end.clone())),
+            std::ops::Bound::Excluded(end) => std::ops::Bound::Excluded(MultiPair::with_infimum(end.clone())),
             _ => std::ops::Bound::Unbounded,
         };
 
@@ -651,9 +632,7 @@ mod tests {
         let mid_range = map.range(2..3).collect::<BTreeSet<_>>();
         assert_eq!(
             mid_range,
-            vec![(&2, &"c"), (&2, &"d"),]
-                .into_iter()
-                .collect::<BTreeSet<_>>()
+            vec![(&2, &"c"), (&2, &"d"),].into_iter().collect::<BTreeSet<_>>()
         );
     }
 
@@ -677,9 +656,7 @@ mod tests {
         let mid_range = map.range(2..3).collect::<BTreeSet<_>>();
         assert_eq!(
             mid_range,
-            vec![(&2, &"c"), (&2, &"d"),]
-                .into_iter()
-                .collect::<BTreeSet<_>>()
+            vec![(&2, &"c"), (&2, &"d"),].into_iter().collect::<BTreeSet<_>>()
         );
 
         let reverse_range = map.range(1..4).rev().collect::<BTreeSet<_>>();
@@ -711,31 +688,22 @@ mod tests {
 
         assert_eq!(
             range,
-            vec![(&1, &"b"), (&1, &"a"),]
-                .into_iter()
-                .collect::<BTreeSet<_>>()
+            vec![(&1, &"b"), (&1, &"a"),].into_iter().collect::<BTreeSet<_>>()
         );
 
         let range = map.get(&2).collect::<BTreeSet<_>>();
         assert_eq!(
             range,
-            vec![(&2, &"d"), (&2, &"c"),]
-                .into_iter()
-                .collect::<BTreeSet<_>>()
+            vec![(&2, &"d"), (&2, &"c"),].into_iter().collect::<BTreeSet<_>>()
         );
 
         let range = map.get(&3).collect::<BTreeSet<_>>();
-        assert_eq!(
-            range,
-            vec![(&3, &"e"),].into_iter().collect::<BTreeSet<_>>()
-        );
+        assert_eq!(range, vec![(&3, &"e"),].into_iter().collect::<BTreeSet<_>>());
 
         let range = map.get(&4).collect::<BTreeSet<_>>();
         assert_eq!(
             range,
-            vec![(&4, &"g"), (&4, &"f"),]
-                .into_iter()
-                .collect::<BTreeSet<_>>()
+            vec![(&4, &"g"), (&4, &"f"),].into_iter().collect::<BTreeSet<_>>()
         );
     }
 

--- a/src/concurrent/multimap.rs
+++ b/src/concurrent/multimap.rs
@@ -1,189 +1,148 @@
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::sync::Arc;
-use std::{borrow::Borrow, iter::FusedIterator, ops::RangeBounds};
+use std::{borrow::Borrow, iter::FusedIterator, ops::{Bound, RangeBounds}};
 
 use parking_lot::Mutex;
 
 use crate::core::node::NodeLike;
-use crate::{cdc::change::ChangeEvent, core::multipair::MultiPair};
+use crate::{cdc::change::ChangeEvent, core::multipair::{MultiPair, MultiPairLike, MultiPairRemoveHelper}};
 
 use super::set::BTreeSet;
 
 #[derive(Debug)]
-pub struct BTreeMultiMap<K, V, Node = Vec<MultiPair<K, V>>>
+pub struct BTreeMultiMap<K, V, Node = Vec<MultiPair<K, V>>, M = MultiPair<K, V>>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
-    pub(crate) set: BTreeSet<MultiPair<K, V>, Node>,
+    pub(crate) set: BTreeSet<M, Node>,
+    marker: PhantomData<(K, V)>,
 }
 
-impl<K, V, Node> Default for BTreeMultiMap<K, V, Node>
+impl<K, V, Node, M> Default for BTreeMultiMap<K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     fn default() -> Self {
         Self {
             set: Default::default(),
+            marker: PhantomData,
         }
     }
 }
 
-pub struct Iter<'a, K, V, Node>
+pub struct Iter<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
-    inner: super::set::Iter<'a, MultiPair<K, V>, Node>,
+    inner: super::set::Iter<'a, M, Node>,
+    marker: PhantomData<(K, V)>,
 }
 
-impl<'a, K, V, Node> Iterator for Iter<'a, K, V, Node>
+impl<'a, K, V, Node, M> Iterator for Iter<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(entry) = self.inner.next() {
-            return Some((&entry.key, &entry.value));
+            return Some((entry.key(), entry.value()));
         }
 
         None
     }
 }
 
-impl<'a, K, V, Node> DoubleEndedIterator for Iter<'a, K, V, Node>
+impl<'a, K, V, Node, M> DoubleEndedIterator for Iter<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         if let Some(entry) = self.inner.next_back() {
-            return Some((&entry.key, &entry.value));
+            return Some((entry.key(), entry.value()));
         }
 
         None
     }
 }
 
-impl<'a, K, V, Node> FusedIterator for Iter<'a, K, V, Node>
+impl<'a, K, V, Node, M> FusedIterator for Iter<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
 }
 
-pub struct RawRange<'a, K, V, Node>
+pub struct Range<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
-    inner: super::set::Range<'a, MultiPair<K, V>, Node>,
+    inner: super::set::Range<'a, M, Node>,
+    marker: PhantomData<(K, V)>,
 }
 
-impl<'a, K, V, Node> Iterator for RawRange<'a, K, V, Node>
+impl<'a, K, V, Node, M> Iterator for Range<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
-{
-    type Item = (&'a K, &'a u64, &'a V);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(entry) = self.inner.next() {
-            return Some((&entry.key, &entry.discriminator, &entry.value));
-        }
-
-        None
-    }
-}
-
-impl<'a, K, V, Node> DoubleEndedIterator for RawRange<'a, K, V, Node>
-where
-    K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
-{
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if let Some(entry) = self.inner.next_back() {
-            return Some((&entry.key, &entry.discriminator, &entry.value));
-        }
-
-        None
-    }
-}
-
-impl<'a, K, V, Node> FusedIterator for RawRange<'a, K, V, Node>
-where
-    K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
-{
-}
-
-pub struct Range<'a, K, V, Node>
-where
-    K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
-{
-    inner: RawRange<'a, K, V, Node>,
-}
-
-impl<'a, K, V, Node> Iterator for Range<'a, K, V, Node>
-where
-    K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(raw_entry) = self.inner.next() {
-            return Some((&raw_entry.0, &raw_entry.2));
-        }
-
-        None
+        self.inner.next().map(|entry| (entry.key(), entry.value()))
     }
 }
 
-impl<'a, K, V, Node> DoubleEndedIterator for Range<'a, K, V, Node>
+impl<'a, K, V, Node, M> DoubleEndedIterator for Range<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if let Some(raw_entry) = self.inner.next_back() {
-            return Some((&raw_entry.0, &raw_entry.2));
-        }
-
-        None
+        self.inner.next_back().map(|entry| (entry.key(), entry.value()))
     }
 }
 
-impl<'a, K, V, Node> FusedIterator for Range<'a, K, V, Node>
+impl<'a, K, V, Node, M> FusedIterator for Range<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
 }
 
-impl<K, V, Node> BTreeMultiMap<K, V, Node>
+impl<K, V, Node, M> BTreeMultiMap<K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     /// Makes a new, empty, persistent `BTreeMultiMap`.
     ///
@@ -202,6 +161,7 @@ where
     pub fn new() -> Self {
         Self {
             set: Default::default(),
+            marker: PhantomData,
         }
     }
     /// Makes a new, empty `BTreeMultiMap` with the given maximum node size. Allocates one vec with
@@ -216,6 +176,7 @@ where
     pub fn with_maximum_node_size(node_capacity: usize) -> Self {
         Self {
             set: BTreeSet::with_maximum_node_size(node_capacity),
+            marker: PhantomData,
         }
     }
     /// Adds full [`Node`] to this multiset. [`Node`] should be correct node with
@@ -249,29 +210,20 @@ where
     /// ```
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
-        MultiPair<K, V>: Borrow<Q> + Ord,
+        M: Borrow<Q>,
         Q: Ord + ?Sized,
     {
         self.set.contains(key)
     }
-    fn _range<Q, R>(&self, range: R) -> Range<'_, K, V, Node>
+    fn _range<Q, R>(&self, range: R) -> Range<'_, K, V, Node, M>
     where
-        MultiPair<K, V>: Borrow<Q> + Ord,
+        M: Borrow<Q>,
         Q: Ord + ?Sized,
         R: RangeBounds<Q>,
     {
         Range {
-            inner: RawRange {
-                inner: super::set::BTreeSet::range(&self.set, range),
-            },
-        }
-    }
-    fn raw_get(&self, key: &K) -> RawRange<'_, K, V, Node> {
-        let infimum = MultiPair::with_infimum(key.clone());
-        let supremum = MultiPair::with_supremum(key.clone());
-
-        RawRange {
-            inner: self.set.range(infimum..supremum),
+            inner: super::set::BTreeSet::range(&self.set, range),
+            marker: PhantomData,
         }
     }
     /// Constructs a double-ended iterator over all key value pairs with the given key in the map.
@@ -290,15 +242,11 @@ where
     /// assert_eq!(all_with_key.len(), 2);
     /// assert_eq!(all_with_key, vec![(&1, &"a"), (&1, &"b")].into_iter().collect::<BTreeSet<_>>());
     /// ```
-    pub fn get(&self, key: &K) -> Range<'_, K, V, Node> {
-        let infimum = MultiPair::with_infimum(key.clone());
-        let supremum = MultiPair::with_supremum(key.clone());
-
-        Range {
-            inner: RawRange {
-                inner: self.set.range(infimum..supremum),
-            },
-        }
+    pub fn get(&self, key: &K) -> Range<'_, K, V, Node, M>
+    where
+        M: Borrow<K>,
+    {
+        self._range((Bound::Included(key), Bound::Included(key)))
     }
     /// Inserts a key-value pair into the multi map.
     ///
@@ -317,23 +265,23 @@ where
     /// assert_eq!(map.insert(37, "c"), None);
     /// ```
     pub fn insert(&self, key: K, value: V) -> Option<V> {
-        let new_entry = MultiPair::new(key, value);
+        let new_entry = M::new(key, value);
 
         self.set
             .put_cdc(new_entry)
             .0
-            .and_then(|pair| Some(pair.value))
+            .map(|pair| pair.into().1)
     }
     /// Inserts a key-value pair into the map and returns old value (if it was
     /// already in set) with [`ChangeEvent`]'s that describes this insert
     /// action.
     #[cfg(feature = "cdc")]
-    pub fn insert_cdc(&self, key: K, value: V) -> (Option<V>, Vec<ChangeEvent<MultiPair<K, V>>>) {
-        let new_entry = MultiPair::new(key, value);
+    pub fn insert_cdc(&self, key: K, value: V) -> (Option<V>, Vec<ChangeEvent<M>>) {
+        let new_entry = M::new(key, value);
 
         let (old_value, cdc) = self.set.put_cdc(new_entry);
 
-        (old_value.and_then(|pair| Some(pair.value)), cdc)
+        (old_value.map(|pair| pair.into().1), cdc)
     }
     /// Removes some key from the map that matches the given key, returning the
     /// key and the value if the key was previously in the map.
@@ -361,82 +309,25 @@ where
     /// ```
     pub fn remove_some<Q>(&self, key: &Q) -> Option<(K, V)>
     where
-        MultiPair<K, V>: Borrow<Q> + Ord,
+        M: Borrow<Q>,
         Q: Ord + ?Sized,
     {
         self.set
             .remove(key)
-            .and_then(|pair| Some((pair.key, pair.value)))
+            .map(Into::into)
     }
     /// Removes some key from the map that matches the given key, returning the
     /// key and the value if the key was previously in the map with
     /// [`ChangeEvent`]'s describing this `remove_some` action.
     #[cfg(feature = "cdc")]
-    pub fn remove_some_cdc<Q>(&self, key: &Q) -> (Option<(K, V)>, Vec<ChangeEvent<MultiPair<K, V>>>)
+    pub fn remove_some_cdc<Q>(&self, key: &Q) -> (Option<(K, V)>, Vec<ChangeEvent<M>>)
     where
-        MultiPair<K, V>: Borrow<Q> + Ord,
+        M: Borrow<Q>,
         Q: Ord + ?Sized,
     {
         let (old_value, cdc) = self.set.remove_cdc(key);
 
-        (old_value.and_then(|pair| Some((pair.key, pair.value))), cdc)
-    }
-    /// Removes a specific key-value pair from the map returning the key and the value if the key
-    /// was previously in the map.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// use indexset::concurrent::multimap::BTreeMultiMap;
-    ///
-    /// let map = BTreeMultiMap::<usize, &str>::new();
-    /// map.insert(1, "b");
-    /// map.insert(1, "a");
-    ///
-    /// assert_eq!(map.remove(&1, &"a"), Some((1, "a")));
-    /// assert_eq!(map.remove(&1, &"b"), Some((1, "b")));
-    /// ```
-    pub fn remove(&self, key: &K, value: &V) -> Option<(K, V)> {
-        let discriminant_to_remove = self.raw_get(&key).find(|pair| pair.2 == value);
-        if let Some(discriminant_to_remove) = discriminant_to_remove {
-            let pair_to_remove = MultiPair {
-                key: discriminant_to_remove.0.clone(),
-                value: discriminant_to_remove.2.clone(),
-                discriminator: *discriminant_to_remove.1,
-            };
-
-            return self
-                .set
-                .remove(&pair_to_remove)
-                .and_then(|pair| Some((pair.key, pair.value)));
-        }
-
-        None
-    }
-    /// Removes a specific key-value pair from the map returning the key and the
-    /// value if the key was previously in the map with [`ChangeEvent`]'s
-    /// describing this `remove_some` action.
-    #[cfg(feature = "cdc")]
-    pub fn remove_cdc(
-        &self,
-        key: &K,
-        value: &V,
-    ) -> (Option<(K, V)>, Vec<ChangeEvent<MultiPair<K, V>>>) {
-        let discriminant_to_remove = self.raw_get(&key).find(|pair| pair.2 == value);
-        if let Some(discriminant_to_remove) = discriminant_to_remove {
-            let pair_to_remove = MultiPair {
-                key: discriminant_to_remove.0.clone(),
-                value: discriminant_to_remove.2.clone(),
-                discriminator: *discriminant_to_remove.1,
-            };
-
-            let (res, evs) = self.set.remove_cdc(&pair_to_remove);
-            return (res.map(|pair| (pair.key, pair.value)), evs);
-        }
-
-        (None, vec![])
+        (old_value.map(Into::into), cdc)
     }
     /// Returns the number of elements in the map.
     ///
@@ -519,9 +410,10 @@ where
     /// let (first_key, first_value) = map.iter().next().unwrap();
     /// assert_eq!((*first_key, *first_value), (1, "a"));
     /// ```
-    pub fn iter(&self) -> Iter<'_, K, V, Node> {
+    pub fn iter(&self) -> Iter<'_, K, V, Node, M> {
         Iter {
             inner: self.set.iter(),
+            marker: PhantomData,
         }
     }
     /// Constructs a double-ended iterator over a sub-range of elements in the map.
@@ -553,39 +445,64 @@ where
     /// }
     /// assert_eq!(Some((&5, &"b")), map.range(4..).next());
     /// ```
-    pub fn range<R>(&self, range: R) -> Range<'_, K, V, Node>
+    pub fn range<R>(&self, range: R) -> Range<'_, K, V, Node, M>
     where
+        M: Borrow<K>,
         R: RangeBounds<K>,
     {
-        let start_bound = range.start_bound();
-        let adjusted_start_bound = match start_bound {
-            std::ops::Bound::Included(start) => {
-                std::ops::Bound::Included(MultiPair::with_infimum(start.clone()))
-            }
-            std::ops::Bound::Excluded(start) => {
-                std::ops::Bound::Excluded(MultiPair::with_supremum(start.clone()))
-            }
-            _ => std::ops::Bound::Unbounded,
-        };
-        let end_bound = range.end_bound();
-        let adjusted_end_bound = match end_bound {
-            std::ops::Bound::Included(end) => {
-                std::ops::Bound::Included(MultiPair::with_supremum(end.clone()))
-            }
-            std::ops::Bound::Excluded(end) => {
-                std::ops::Bound::Excluded(MultiPair::with_infimum(end.clone()))
-            }
-            _ => std::ops::Bound::Unbounded,
-        };
+        self._range(range)
+    }
+}
 
-        self._range((adjusted_start_bound, adjusted_end_bound))
+impl<K, V, Node, M> BTreeMultiMap<K, V, Node, M>
+where
+    K: Debug + Send + Ord + Clone + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + MultiPairRemoveHelper<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
+{
+    /// Removes a specific key-value pair from the map returning the key and the value if the key
+    /// was previously in the map.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use indexset::concurrent::multimap::BTreeMultiMap;
+    ///
+    /// let map = BTreeMultiMap::<usize, &str>::new();
+    /// map.insert(1, "b");
+    /// map.insert(1, "a");
+    ///
+    /// assert_eq!(map.remove(&1, &"a"), Some((1, "a")));
+    /// assert_eq!(map.remove(&1, &"b"), Some((1, "b")));
+    /// ```
+    pub fn remove(&self, key: &K, value: &V) -> Option<(K, V)> {
+        M::remove_from(&self.set, key, value)
+    }
+
+    /// Removes a specific key-value pair from the map returning the key and the
+    /// value if the key was previously in the map with [`ChangeEvent`]'s
+    /// describing this `remove_some` action.
+    #[cfg(feature = "cdc")]
+    pub fn remove_cdc(
+        &self,
+        key: &K,
+        value: &V,
+    ) -> (Option<(K, V)>, Vec<ChangeEvent<M>>) {
+        M::remove_cdc_from(&self.set, key, value)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::BTreeMultiMap;
+    use crate::core::multipair::{MultiPairLike, OrdMultiPair, RandomMultiPair};
     use crate::BTreeSet;
+    use std::borrow::Borrow;
+    use std::fmt::Debug;
+    use std::ops::Bound::{Excluded, Unbounded};
 
     #[test]
     fn test_insert_works_as_expected() {
@@ -633,6 +550,10 @@ mod tests {
             .into_iter()
             .collect::<BTreeSet<_>>();
         assert_eq!(all_actual_pairs, all_expected_pairs);
+
+        let all_ranged_pairs = map.range(1..2).map(|(k, v)| (*k, *v)).collect::<BTreeSet<_>>();
+        assert_eq!(all_ranged_pairs, all_expected_pairs);
+        assert!(map.range(1..1).next().is_none());
     }
 
     #[test]
@@ -657,10 +578,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_range_works_as_expected() {
+    fn assert_range_works_as_expected<M>()
+    where
+        M: MultiPairLike<usize, &'static str> + Borrow<usize> + Debug + Clone + Send + 'static,
+    {
         let maximum_node_size = 3;
-        let map = BTreeMultiMap::<usize, &str>::with_maximum_node_size(maximum_node_size);
+        let map = BTreeMultiMap::<usize, &'static str, Vec<M>, M>::with_maximum_node_size(
+            maximum_node_size,
+        );
 
         map.insert(1usize, "a");
         map.insert(1usize, "b");
@@ -687,7 +612,7 @@ mod tests {
             reverse_range,
             vec![(&3, &"e"), (&2, &"d"), (&2, &"c"), (&1, &"b"), (&1, &"a"),]
                 .into_iter()
-                .collect::<BTreeSet<_>>()
+            .collect::<BTreeSet<_>>()
         );
 
         let empty_range = map.range(5..).collect::<BTreeSet<_>>();
@@ -695,9 +620,52 @@ mod tests {
     }
 
     #[test]
-    fn test_get_works_as_expected() {
+    fn test_range_works_as_expected() {
+        assert_range_works_as_expected::<RandomMultiPair<usize, &'static str>>();
+        assert_range_works_as_expected::<OrdMultiPair<usize, &'static str>>();
+    }
+
+    fn assert_range_excludes_values_at_bounds<M>()
+    where
+        M: MultiPairLike<usize, &'static str> + Borrow<usize> + Debug + Clone + Send + 'static,
+    {
+        let map = BTreeMultiMap::<usize, &'static str, Vec<M>, M>::with_maximum_node_size(10);
+
+        map.insert(1usize, "a");
+        map.insert(1usize, "b");
+        map.insert(2usize, "c");
+        map.insert(2usize, "d");
+        map.insert(3usize, "e");
+        map.insert(3usize, "f");
+
+        assert_eq!(
+            map.range((Excluded(&1), Unbounded)).collect::<BTreeSet<_>>(),
+            vec![(&2, &"c"), (&2, &"d"), (&3, &"e"), (&3, &"f")]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+        );
+        assert_eq!(
+            map.range((Unbounded, Excluded(&3))).collect::<BTreeSet<_>>(),
+            vec![(&1, &"a"), (&1, &"b"), (&2, &"c"), (&2, &"d")]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+        );
+    }
+
+    #[test]
+    fn test_range_excludes_all_values_at_bounds() {
+        assert_range_excludes_values_at_bounds::<RandomMultiPair<usize, &'static str>>();
+        assert_range_excludes_values_at_bounds::<OrdMultiPair<usize, &'static str>>();
+    }
+
+    fn assert_get_works_as_expected<M>()
+    where
+        M: MultiPairLike<usize, &'static str> + Borrow<usize> + Debug + Clone + Send + 'static,
+    {
         let maximum_node_size = 10;
-        let map = BTreeMultiMap::<usize, &str>::with_maximum_node_size(maximum_node_size);
+        let map = BTreeMultiMap::<usize, &'static str, Vec<M>, M>::with_maximum_node_size(
+            maximum_node_size,
+        );
 
         map.insert(1usize, "a");
         map.insert(1usize, "b");
@@ -737,6 +705,12 @@ mod tests {
                 .into_iter()
                 .collect::<BTreeSet<_>>()
         );
+    }
+
+    #[test]
+    fn test_get_works_as_expected() {
+        assert_get_works_as_expected::<RandomMultiPair<usize, &'static str>>();
+        assert_get_works_as_expected::<OrdMultiPair<usize, &'static str>>();
     }
 
     #[test]

--- a/src/concurrent/multimap.rs
+++ b/src/concurrent/multimap.rs
@@ -149,7 +149,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(raw_entry) = self.inner.next() {
-            return Some((&raw_entry.0, &raw_entry.2));
+            return Some((raw_entry.0, raw_entry.2));
         }
 
         None
@@ -164,7 +164,7 @@ where
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         if let Some(raw_entry) = self.inner.next_back() {
-            return Some((&raw_entry.0, &raw_entry.2));
+            return Some((raw_entry.0, raw_entry.2));
         }
 
         None
@@ -319,7 +319,7 @@ where
     pub fn insert(&self, key: K, value: V) -> Option<V> {
         let new_entry = MultiPair::new(key, value);
 
-        self.set.put_cdc(new_entry).0.and_then(|pair| Some(pair.value))
+        self.set.put_cdc(new_entry).0.map(|pair| pair.value)
     }
     /// Inserts a key-value pair into the map and returns old value (if it was
     /// already in set) with [`ChangeEvent`]'s that describes this insert
@@ -330,7 +330,7 @@ where
 
         let (old_value, cdc) = self.set.put_cdc(new_entry);
 
-        (old_value.and_then(|pair| Some(pair.value)), cdc)
+        (old_value.map(|pair| pair.value), cdc)
     }
     /// Removes some key from the map that matches the given key, returning the
     /// key and the value if the key was previously in the map.
@@ -361,12 +361,13 @@ where
         MultiPair<K, V>: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        self.set.remove(key).and_then(|pair| Some((pair.key, pair.value)))
+        self.set.remove(key).map(|pair| (pair.key, pair.value))
     }
     /// Removes some key from the map that matches the given key, returning the
     /// key and the value if the key was previously in the map with
     /// [`ChangeEvent`]'s describing this `remove_some` action.
     #[cfg(feature = "cdc")]
+    #[allow(clippy::type_complexity)]
     pub fn remove_some_cdc<Q>(&self, key: &Q) -> (Option<(K, V)>, Vec<ChangeEvent<MultiPair<K, V>>>)
     where
         MultiPair<K, V>: Borrow<Q> + Ord,
@@ -374,7 +375,7 @@ where
     {
         let (old_value, cdc) = self.set.remove_cdc(key);
 
-        (old_value.and_then(|pair| Some((pair.key, pair.value))), cdc)
+        (old_value.map(|pair| (pair.key, pair.value)), cdc)
     }
     /// Removes a specific key-value pair from the map returning the key and the value if the key
     /// was previously in the map.
@@ -394,7 +395,7 @@ where
     /// assert_eq!(map.remove(&1, &"b"), Some((1, "b")));
     /// ```
     pub fn remove(&self, key: &K, value: &V) -> Option<(K, V)> {
-        let discriminant_to_remove = self.raw_get(&key).find(|pair| pair.2 == value);
+        let discriminant_to_remove = self.raw_get(key).find(|pair| pair.2 == value);
         if let Some(discriminant_to_remove) = discriminant_to_remove {
             let pair_to_remove = MultiPair {
                 key: discriminant_to_remove.0.clone(),
@@ -402,10 +403,7 @@ where
                 discriminator: *discriminant_to_remove.1,
             };
 
-            return self
-                .set
-                .remove(&pair_to_remove)
-                .and_then(|pair| Some((pair.key, pair.value)));
+            return self.set.remove(&pair_to_remove).map(|pair| (pair.key, pair.value));
         }
 
         None
@@ -414,8 +412,9 @@ where
     /// value if the key was previously in the map with [`ChangeEvent`]'s
     /// describing this `remove_some` action.
     #[cfg(feature = "cdc")]
+    #[allow(clippy::type_complexity)]
     pub fn remove_cdc(&self, key: &K, value: &V) -> (Option<(K, V)>, Vec<ChangeEvent<MultiPair<K, V>>>) {
-        let discriminant_to_remove = self.raw_get(&key).find(|pair| pair.2 == value);
+        let discriminant_to_remove = self.raw_get(key).find(|pair| pair.2 == value);
         if let Some(discriminant_to_remove) = discriminant_to_remove {
             let pair_to_remove = MultiPair {
                 key: discriminant_to_remove.0.clone(),
@@ -445,6 +444,23 @@ where
     /// ```
     pub fn len(&self) -> usize {
         self.set.len()
+    }
+    /// Returns `true` if the multimap contains no elements.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use indexset::concurrent::multimap::BTreeMultiMap;
+    ///
+    /// let mut a = BTreeMultiMap::<usize, &str>::new();
+    /// assert!(a.is_empty());
+    /// a.insert(1, "a");
+    /// assert!(!a.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
     }
     /// Returns the total number of allocated slots across all internal nodes.
     ///

--- a/src/concurrent/operation.rs
+++ b/src/concurrent/operation.rs
@@ -32,10 +32,7 @@ where
                     if Arc::ptr_eq(entry.value(), &old_node) {
                         let mut cdc = vec![];
                         #[cfg(feature = "cdc")]
-                        let max_value = guard
-                            .max()
-                            .expect("node should be non empty if split")
-                            .clone();
+                        let max_value = guard.max().expect("node should be non empty if split").clone();
                         entry.remove();
                         let mut new_vec = guard.halve();
 

--- a/src/concurrent/operation.rs
+++ b/src/concurrent/operation.rs
@@ -48,7 +48,7 @@ where
                         let mut old_value: Option<T> = None;
                         let mut insert_attempted = false;
                         if let Some(max) = guard.max().cloned() {
-                            if max > value {
+                            if max >= value {
                                 let (inserted, idx) = NodeLike::insert(&mut *guard, value.clone());
                                 insert_attempted = true;
                                 if !inserted {

--- a/src/concurrent/ref.rs
+++ b/src/concurrent/ref.rs
@@ -1,11 +1,11 @@
-use std::marker::PhantomData;
-use parking_lot::{ArcMutexGuard, RawMutex};
 use crate::core::node::NodeLike;
+use parking_lot::{ArcMutexGuard, RawMutex};
+use std::marker::PhantomData;
 
 pub struct Ref<T: Ord + Clone + Send, Node: NodeLike<T> + Send> {
     pub(super) node_guard: ArcMutexGuard<RawMutex, Node>,
     pub(super) position: usize,
-    pub(super) phantom_data: PhantomData<T>
+    pub(super) phantom_data: PhantomData<T>,
 }
 
 impl<T: Ord + Clone + Send, Node: NodeLike<T> + Send> Ref<T, Node> {

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -139,8 +139,7 @@ where
         loop {
             let mut cdc = vec![];
             let _global_guard = self.index_lock.read();
-            let target_node_entry = match self.index.lower_bound(std::ops::Bound::Included(&value))
-            {
+            let target_node_entry = match self.index.lower_bound(std::ops::Bound::Included(&value)) {
                 Some(entry) => entry,
                 None => {
                     if let Some(last) = self.index.back() {
@@ -231,8 +230,7 @@ where
                         #[cfg(feature = "cdc")]
                         {
                             for unassigned_event in value_cdc {
-                                let event_id =
-                                    self.event_id.fetch_add(1, Ordering::AcqRel).into();
+                                let event_id = self.event_id.fetch_add(1, Ordering::AcqRel).into();
                                 cdc.push(unassigned_event.assign_id(event_id));
                             }
                         }
@@ -246,8 +244,7 @@ where
                         #[cfg(feature = "cdc")]
                         {
                             for unassigned_event in value_cdc {
-                                let event_id =
-                                    self.event_id.fetch_add(1, Ordering::AcqRel).into();
+                                let event_id = self.event_id.fetch_add(1, Ordering::AcqRel).into();
                                 cdc.push(unassigned_event.assign_id(event_id));
                             }
                         }
@@ -365,9 +362,7 @@ where
         loop {
             let mut cdc = vec![];
             let _global_guard = self.index_lock.read();
-            if let Some(target_node_entry) =
-                self.index.lower_bound(Bound::Included(&value))
-            {
+            if let Some(target_node_entry) = self.index.lower_bound(Bound::Included(&value)) {
                 let mut node_guard = target_node_entry.value().lock_arc();
                 let old_max = node_guard.max().cloned();
                 let deleted = NodeLike::delete(&mut *node_guard, value);
@@ -383,9 +378,7 @@ where
                             // is correct as node is locked and current thread is the only that can
                             // fetch event_id, so events for this node will have monotonic id's.
                             event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
-                            max_value: old_max
-                                .clone()
-                                .expect("Max value should exist as Node is not empty"),
+                            max_value: old_max.clone().expect("Max value should exist as Node is not empty"),
                             value: deleted.clone(),
                             index: idx,
                         };
@@ -518,10 +511,7 @@ where
         None
     }
     pub fn len(&self) -> usize {
-        self.index
-            .iter()
-            .map(|node| node.value().lock().len())
-            .sum()
+        self.index.iter().map(|node| node.value().lock().len()).sum()
     }
     pub fn capacity(&self) -> usize {
         self.index
@@ -675,9 +665,7 @@ where
                     if let Some(current_node_entry) = self.tree.index.iter().find(|e| {
                         Arc::ptr_eq(
                             e.value(),
-                            self.current_front_node
-                                .as_ref()
-                                .expect("was just set before"),
+                            self.current_front_node.as_ref().expect("was just set before"),
                         )
                     }) {
                         if let Some(next_node_entry) = current_node_entry.next() {
@@ -685,10 +673,8 @@ where
 
                             if let Some(back_entry) = self.current_back_node.as_ref() {
                                 if Arc::ptr_eq(next_node_entry.value(), back_entry) {
-                                    self.current_front_node_guard =
-                                        self.current_back_node_guard.take();
-                                    self.current_front_node_iter =
-                                        self.current_back_node_iter.take();
+                                    self.current_front_node_guard = self.current_back_node_guard.take();
+                                    self.current_front_node_iter = self.current_back_node_iter.take();
                                 }
                                 continue;
                             }
@@ -738,15 +724,9 @@ where
                 });
 
                 if let Some(current_front_value) = self.current_front_value.as_ref() {
-                    let g = self
-                        .current_front_node_guard
-                        .as_mut()
-                        .expect("was just set before");
+                    let g = self.current_front_node_guard.as_mut().expect("was just set before");
                     if let Some(rank) = g.rank(Bound::Excluded(current_front_value), true) {
-                        let i = self
-                            .current_front_node_iter
-                            .as_mut()
-                            .expect("was just set before");
+                        let i = self.current_front_node_iter.as_mut().expect("was just set before");
                         if let Some(v) = i.nth(rank + 1) {
                             if let Some(current_back_value) = self.current_back_value.as_ref() {
                                 if v.ge(current_back_value) {
@@ -790,12 +770,8 @@ where
                             continue;
                         }
 
-                        self.current_back_node_guard = Some(
-                            self.current_back_node
-                                .as_ref()
-                                .expect("was just set before")
-                                .lock_arc(),
-                        );
+                        self.current_back_node_guard =
+                            Some(self.current_back_node.as_ref().expect("was just set before").lock_arc());
                         self.current_back_node_iter = Some(unsafe {
                             std::mem::transmute(
                                 self.current_back_node_guard
@@ -830,33 +806,24 @@ where
                     self.current_back_node_iter = None;
                     self.current_back_node_guard = None;
 
-                    if let Some(current_node_entry) = self.tree.index.iter().find(|e| {
-                        Arc::ptr_eq(
-                            e.value(),
-                            self.current_back_node
-                                .as_ref()
-                                .expect("was just set before"),
-                        )
-                    }) {
+                    if let Some(current_node_entry) =
+                        self.tree.index.iter().find(|e| {
+                            Arc::ptr_eq(e.value(), self.current_back_node.as_ref().expect("was just set before"))
+                        })
+                    {
                         if let Some(prev_node_entry) = current_node_entry.prev() {
                             self.current_back_node = Some(prev_node_entry.value().clone());
 
                             if let Some(front_entry) = self.current_front_node.as_ref() {
                                 if Arc::ptr_eq(prev_node_entry.value(), front_entry) {
-                                    self.current_back_node_guard =
-                                        self.current_front_node_guard.take();
-                                    self.current_back_node_iter =
-                                        self.current_front_node_iter.take();
+                                    self.current_back_node_guard = self.current_front_node_guard.take();
+                                    self.current_back_node_iter = self.current_front_node_iter.take();
                                 }
                                 continue;
                             }
 
-                            self.current_back_node_guard = Some(
-                                self.current_back_node
-                                    .as_ref()
-                                    .expect("was just set before")
-                                    .lock_arc(),
-                            );
+                            self.current_back_node_guard =
+                                Some(self.current_back_node.as_ref().expect("was just set before").lock_arc());
                             self.current_back_node_iter = Some(unsafe {
                                 std::mem::transmute(
                                     self.current_back_node_guard
@@ -880,12 +847,8 @@ where
                     }
                 }
             } else {
-                self.current_back_node_guard = Some(
-                    self.current_back_node
-                        .as_ref()
-                        .expect("was just set before")
-                        .lock_arc(),
-                );
+                self.current_back_node_guard =
+                    Some(self.current_back_node.as_ref().expect("was just set before").lock_arc());
                 self.current_back_node_iter = Some(unsafe {
                     std::mem::transmute(
                         self.current_back_node_guard
@@ -896,15 +859,9 @@ where
                 });
 
                 if let Some(current_back_value) = self.current_back_value.as_ref() {
-                    let g = self
-                        .current_back_node_guard
-                        .as_mut()
-                        .expect("was just set before");
+                    let g = self.current_back_node_guard.as_mut().expect("was just set before");
                     if let Some(rank) = g.rank(Bound::Excluded(current_back_value), false) {
-                        let i = self
-                            .current_back_node_iter
-                            .as_mut()
-                            .expect("was just set before");
+                        let i = self.current_back_node_iter.as_mut().expect("was just set before");
                         if let Some(v) = i.nth_back(rank + 1) {
                             if let Some(current_front_value) = self.current_front_value.as_ref() {
                                 if v.le(current_front_value) {
@@ -924,10 +881,7 @@ where
     }
 }
 
-impl<'a, T: Debug + Ord + Clone + Send, Node: NodeLike<T> + Send + 'static> FusedIterator
-    for Iter<'a, T, Node>
-{
-}
+impl<'a, T: Debug + Ord + Clone + Send, Node: NodeLike<T> + Send + 'static> FusedIterator for Iter<'a, T, Node> {}
 
 impl<'a, T, Node> IntoIterator for &'a BTreeSet<T, Node>
 where
@@ -1033,11 +987,7 @@ where
         if front_value.is_none() && back_value.is_none() {
             // in this case we iter full or no iter at all
             if start_bound != Bound::Unbounded || end_bound != Bound::Unbounded {
-                if let Some(max) = btree
-                    .index
-                    .back()
-                    .and_then(|e| e.value().lock_arc().max().cloned())
-                {
+                if let Some(max) = btree.index.back().and_then(|e| e.value().lock_arc().max().cloned()) {
                     if let Bound::Included(v) = start_bound {
                         if v > max.borrow() {
                             met = true;
@@ -1049,11 +999,7 @@ where
                     }
                 }
 
-                if let Some(min) = btree
-                    .index
-                    .front()
-                    .and_then(|e| e.value().lock_arc().min().cloned())
-                {
+                if let Some(min) = btree.index.front().and_then(|e| e.value().lock_arc().min().cloned()) {
                     if let Bound::Included(v) = end_bound {
                         if v < min.borrow() {
                             met = true;
@@ -1299,8 +1245,7 @@ where
                 front_entry_guard.drain(potential_front_position..);
                 if !front_entry_guard.is_empty() {
                     let new_front_max = front_entry_guard.last().unwrap().clone();
-                    self.index
-                        .insert(new_front_max, front_entry.value().clone());
+                    self.index.insert(new_front_max, front_entry.value().clone());
                 }
 
                 // The back from the right
@@ -1462,12 +1407,7 @@ mod tests {
 
             let expected_next_back = 20 - i;
             let actual_next_back = iter.next_back();
-            assert_eq!(
-                actual_next_back,
-                Some(&expected_next_back),
-                "Tree: {:?}",
-                tree
-            );
+            assert_eq!(actual_next_back, Some(&expected_next_back), "Tree: {:?}", tree);
         }
         assert_eq!(iter.next(), None);
         assert_eq!(iter.next_back(), None);
@@ -1498,12 +1438,7 @@ mod tests {
         let btree: BTreeSet<usize> = BTreeSet::from_iter(0..10);
         assert_eq!(btree.range((Included(5), Included(10))).count(), 5);
         assert_eq!(btree.range((Included(5), Included(11))).count(), 5);
-        assert_eq!(
-            btree
-                .range((Included(5), Included(10 + DEFAULT_INNER_SIZE)))
-                .count(),
-            5
-        );
+        assert_eq!(btree.range((Included(5), Included(10 + DEFAULT_INNER_SIZE))).count(), 5);
         assert_eq!(btree.range((Included(0), Included(11))).count(), 10);
     }
 
@@ -1530,10 +1465,7 @@ mod tests {
             btree.range(0..=DEFAULT_INNER_SIZE + 1).count(),
             (0..=DEFAULT_INNER_SIZE + 1).count()
         );
-        assert_eq!(
-            btree.iter().rev().count(),
-            (0..(DEFAULT_INNER_SIZE + 10)).count()
-        );
+        assert_eq!(btree.iter().rev().count(), (0..(DEFAULT_INNER_SIZE + 10)).count());
         assert_eq!(
             btree.range(0..DEFAULT_INNER_SIZE).rev().count(),
             (0..DEFAULT_INNER_SIZE).count()
@@ -1565,12 +1497,7 @@ mod tests {
         assert_eq!(btree.range(..1).rev().count(), 0);
 
         assert_eq!(btree.range(..DEFAULT_INNER_SIZE).count(), 0);
-        assert_eq!(
-            btree
-                .range(DEFAULT_INNER_SIZE..DEFAULT_INNER_SIZE * 2)
-                .count(),
-            0
-        );
+        assert_eq!(btree.range(DEFAULT_INNER_SIZE..DEFAULT_INNER_SIZE * 2).count(), 0);
     }
 
     #[test]
@@ -1684,11 +1611,7 @@ mod tests {
         for i in 0..NUM_ELEMENTS {
             set.insert(i);
         }
-        assert_eq!(
-            set.len(),
-            NUM_ELEMENTS as usize,
-            "Incorrect size after insertion"
-        );
+        assert_eq!(set.len(), NUM_ELEMENTS as usize, "Incorrect size after insertion");
 
         let num_threads = 8;
         let elements_per_thread = NUM_ELEMENTS / num_threads;
@@ -1709,21 +1632,13 @@ mod tests {
             handle.join().unwrap();
         }
 
-        assert_eq!(
-            set.len(),
-            NUM_ELEMENTS as usize / 2,
-            "Incorrect size after removal"
-        );
+        assert_eq!(set.len(), NUM_ELEMENTS as usize / 2, "Incorrect size after removal");
 
         for i in 0..NUM_ELEMENTS {
             if i % 2 == 0 {
                 assert!(set.contains(&i), "Even number {} should be in the set", i);
             } else {
-                assert!(
-                    !set.contains(&i),
-                    "Odd number {} should not be in the set",
-                    i
-                );
+                assert!(!set.contains(&i), "Odd number {} should not be in the set", i);
             }
         }
     }
@@ -1776,10 +1691,7 @@ mod tests {
         assert_eq!(set.range(5..=8).collect::<Vec<_>>(), vec![&5, &6, &7, &8]);
         assert_eq!(set.range(5..8).collect::<Vec<_>>(), vec![&5, &6, &7]);
 
-        assert_eq!(
-            set.range(10..=13).collect::<Vec<_>>(),
-            vec![&10, &11, &12, &13]
-        );
+        assert_eq!(set.range(10..=13).collect::<Vec<_>>(), vec![&10, &11, &12, &13]);
         assert_eq!(set.range(10..13).collect::<Vec<_>>(), vec![&10, &11, &12]);
 
         // Last value of the node
@@ -1803,23 +1715,11 @@ mod tests {
         assert_eq!(set.range(2..5).collect::<Vec<_>>(), vec![&2, &3, &4]);
 
         // Full node
-        assert_eq!(
-            set.range(0..=4).collect::<Vec<_>>(),
-            vec![&0, &1, &2, &3, &4]
-        );
-        assert_eq!(
-            set.range(0..5).collect::<Vec<_>>(),
-            vec![&0, &1, &2, &3, &4]
-        );
+        assert_eq!(set.range(0..=4).collect::<Vec<_>>(), vec![&0, &1, &2, &3, &4]);
+        assert_eq!(set.range(0..5).collect::<Vec<_>>(), vec![&0, &1, &2, &3, &4]);
 
-        assert_eq!(
-            set.range(5..=9).collect::<Vec<_>>(),
-            vec![&5, &6, &7, &8, &9]
-        );
-        assert_eq!(
-            set.range(5..10).collect::<Vec<_>>(),
-            vec![&5, &6, &7, &8, &9]
-        );
+        assert_eq!(set.range(5..=9).collect::<Vec<_>>(), vec![&5, &6, &7, &8, &9]);
+        assert_eq!(set.range(5..10).collect::<Vec<_>>(), vec![&5, &6, &7, &8, &9]);
 
         assert_eq!(
             set.range(10..=19).collect::<Vec<_>>(),
@@ -1834,10 +1734,7 @@ mod tests {
         assert_eq!(set.range(3..=6).collect::<Vec<_>>(), vec![&3, &4, &5, &6]);
         assert_eq!(set.range(3..7).collect::<Vec<_>>(), vec![&3, &4, &5, &6]);
 
-        assert_eq!(
-            set.range(8..=11).collect::<Vec<_>>(),
-            vec![&8, &9, &10, &11]
-        );
+        assert_eq!(set.range(8..=11).collect::<Vec<_>>(), vec![&8, &9, &10, &11]);
         assert_eq!(set.range(8..12).collect::<Vec<_>>(), vec![&8, &9, &10, &11]);
 
         // REVERSED
@@ -1853,26 +1750,14 @@ mod tests {
         assert_eq!(set.range(10..11).rev().collect::<Vec<_>>(), vec![&10]);
 
         // From first value to middle
-        assert_eq!(
-            set.range(0..=3).rev().collect::<Vec<_>>(),
-            vec![&3, &2, &1, &0]
-        );
+        assert_eq!(set.range(0..=3).rev().collect::<Vec<_>>(), vec![&3, &2, &1, &0]);
         assert_eq!(set.range(0..3).rev().collect::<Vec<_>>(), vec![&2, &1, &0]);
 
-        assert_eq!(
-            set.range(5..=8).rev().collect::<Vec<_>>(),
-            vec![&8, &7, &6, &5]
-        );
+        assert_eq!(set.range(5..=8).rev().collect::<Vec<_>>(), vec![&8, &7, &6, &5]);
         assert_eq!(set.range(5..8).rev().collect::<Vec<_>>(), vec![&7, &6, &5]);
 
-        assert_eq!(
-            set.range(10..=13).rev().collect::<Vec<_>>(),
-            vec![&13, &12, &11, &10]
-        );
-        assert_eq!(
-            set.range(10..13).rev().collect::<Vec<_>>(),
-            vec![&12, &11, &10]
-        );
+        assert_eq!(set.range(10..=13).rev().collect::<Vec<_>>(), vec![&13, &12, &11, &10]);
+        assert_eq!(set.range(10..13).rev().collect::<Vec<_>>(), vec![&12, &11, &10]);
 
         // Last value of the node
         assert_eq!(set.range(4..=4).rev().collect::<Vec<_>>(), vec![&4]);
@@ -1885,14 +1770,8 @@ mod tests {
         assert_eq!(set.range(19..20).rev().collect::<Vec<_>>(), vec![&19]);
 
         // From middle to last value of the node
-        assert_eq!(
-            set.range(17..=19).rev().collect::<Vec<_>>(),
-            vec![&19, &18, &17]
-        );
-        assert_eq!(
-            set.range(17..20).rev().collect::<Vec<_>>(),
-            vec![&19, &18, &17]
-        );
+        assert_eq!(set.range(17..=19).rev().collect::<Vec<_>>(), vec![&19, &18, &17]);
+        assert_eq!(set.range(17..20).rev().collect::<Vec<_>>(), vec![&19, &18, &17]);
 
         assert_eq!(set.range(7..=9).rev().collect::<Vec<_>>(), vec![&9, &8, &7]);
         assert_eq!(set.range(7..10).rev().collect::<Vec<_>>(), vec![&9, &8, &7]);
@@ -1901,23 +1780,11 @@ mod tests {
         assert_eq!(set.range(2..5).rev().collect::<Vec<_>>(), vec![&4, &3, &2]);
 
         // Full node
-        assert_eq!(
-            set.range(0..=4).rev().collect::<Vec<_>>(),
-            vec![&4, &3, &2, &1, &0]
-        );
-        assert_eq!(
-            set.range(0..5).rev().collect::<Vec<_>>(),
-            vec![&4, &3, &2, &1, &0]
-        );
+        assert_eq!(set.range(0..=4).rev().collect::<Vec<_>>(), vec![&4, &3, &2, &1, &0]);
+        assert_eq!(set.range(0..5).rev().collect::<Vec<_>>(), vec![&4, &3, &2, &1, &0]);
 
-        assert_eq!(
-            set.range(5..=9).rev().collect::<Vec<_>>(),
-            vec![&9, &8, &7, &6, &5]
-        );
-        assert_eq!(
-            set.range(5..10).rev().collect::<Vec<_>>(),
-            vec![&9, &8, &7, &6, &5]
-        );
+        assert_eq!(set.range(5..=9).rev().collect::<Vec<_>>(), vec![&9, &8, &7, &6, &5]);
+        assert_eq!(set.range(5..10).rev().collect::<Vec<_>>(), vec![&9, &8, &7, &6, &5]);
 
         assert_eq!(
             set.range(10..=19).rev().collect::<Vec<_>>(),
@@ -1929,23 +1796,11 @@ mod tests {
         );
 
         // Node intersection
-        assert_eq!(
-            set.range(3..=6).rev().collect::<Vec<_>>(),
-            vec![&6, &5, &4, &3]
-        );
-        assert_eq!(
-            set.range(3..7).rev().collect::<Vec<_>>(),
-            vec![&6, &5, &4, &3]
-        );
+        assert_eq!(set.range(3..=6).rev().collect::<Vec<_>>(), vec![&6, &5, &4, &3]);
+        assert_eq!(set.range(3..7).rev().collect::<Vec<_>>(), vec![&6, &5, &4, &3]);
 
-        assert_eq!(
-            set.range(8..=11).rev().collect::<Vec<_>>(),
-            vec![&11, &10, &9, &8]
-        );
-        assert_eq!(
-            set.range(8..12).rev().collect::<Vec<_>>(),
-            vec![&11, &10, &9, &8]
-        );
+        assert_eq!(set.range(8..=11).rev().collect::<Vec<_>>(), vec![&11, &10, &9, &8]);
+        assert_eq!(set.range(8..12).rev().collect::<Vec<_>>(), vec![&11, &10, &9, &8]);
 
         // Non-existent range
         assert!(set.range(20..).collect::<Vec<_>>().is_empty());

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -153,7 +153,7 @@ where
                         let first_node = Arc::new(Mutex::new(first_node));
 
                         drop(_global_guard);
-                        if self.index_lock.try_write().is_ok() {
+                        if let Ok(_write_guard) = self.index_lock.try_write() {
                             #[cfg(feature = "cdc")]
                             {
                                 let node_insertion = ChangeEvent::CreateNode {
@@ -1791,7 +1791,7 @@ mod tests {
         }
 
         let set_clone = Arc::clone(&set);
-        let _ = thread::spawn(move || {
+        let handle = thread::spawn(move || {
             for _ in 0..1000 {
                 let mut _sum = 0;
                 for &value in set_clone.iter() {
@@ -1803,5 +1803,6 @@ mod tests {
         for i in 10_000..20_000 {
             set.insert(i);
         }
+        handle.join().unwrap();
     }
 }

--- a/src/concurrent/set.rs
+++ b/src/concurrent/set.rs
@@ -132,6 +132,7 @@ where
         self.index.insert(node_id, Arc::new(Mutex::new(node)));
     }
 
+    #[allow(clippy::type_complexity)]
     pub(crate) fn put_cdc_checked(
         &self,
         value: T,
@@ -152,7 +153,7 @@ where
                         let first_node = Arc::new(Mutex::new(first_node));
 
                         drop(_global_guard);
-                        if let Ok(_) = self.index_lock.try_write() {
+                        if self.index_lock.try_write().is_ok() {
                             #[cfg(feature = "cdc")]
                             {
                                 let node_insertion = ChangeEvent::CreateNode {
@@ -199,11 +200,8 @@ where
                         return Ok((None, cdc));
                     }
 
-                    if old_max.is_some() {
-                        operation = Some(Operation::UpdateMax(
-                            target_node_entry.value().clone(),
-                            old_max.unwrap(),
-                        ))
+                    if let Some(old_max) = old_max {
+                        operation = Some(Operation::UpdateMax(target_node_entry.value().clone(), old_max))
                     } else {
                         return Ok((None, cdc));
                     }
@@ -359,69 +357,64 @@ where
         T: Borrow<Q>,
         Q: Ord + ?Sized,
     {
-        loop {
-            let mut cdc = vec![];
-            let _global_guard = self.index_lock.read();
-            if let Some(target_node_entry) = self.index.lower_bound(Bound::Included(&value)) {
-                let mut node_guard = target_node_entry.value().lock_arc();
-                let old_max = node_guard.max().cloned();
-                let deleted = NodeLike::delete(&mut *node_guard, value);
-                if deleted.is_none() {
-                    return (None, cdc);
-                }
-                let (deleted, idx) = deleted.expect("should be ok as checked before");
-
-                let operation = if node_guard.len() > 0 {
-                    #[cfg(feature = "cdc")]
-                    {
-                        let node_element_removal = ChangeEvent::RemoveAt {
-                            // is correct as node is locked and current thread is the only that can
-                            // fetch event_id, so events for this node will have monotonic id's.
-                            event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
-                            max_value: old_max.clone().expect("Max value should exist as Node is not empty"),
-                            value: deleted.clone(),
-                            index: idx,
-                        };
-                        cdc.push(node_element_removal);
-                    }
-
-                    if old_max.as_ref() == node_guard.max() {
-                        return (Some(deleted), cdc);
-                    }
-
-                    Some(Operation::UpdateMax(
-                        target_node_entry.value().clone(),
-                        old_max.unwrap(),
-                    ))
-                } else {
-                    Some(Operation::MakeUnreachable(
-                        target_node_entry.value().clone(),
-                        old_max.unwrap(),
-                    ))
-                };
-
-                drop(node_guard);
-                drop(_global_guard);
-
-                let _global_guard = self.index_lock.write();
-
-                return if let Ok((_, value_cdc)) = operation.unwrap().commit(&self.index) {
-                    #[cfg(feature = "cdc")]
-                    {
-                        for unassigned_event in value_cdc {
-                            let event_id = self.event_id.fetch_add(1, Ordering::AcqRel).into();
-                            cdc.push(unassigned_event.assign_id(event_id));
-                        }
-                    }
-                    (Some(deleted), cdc)
-                } else {
-                    (Some(deleted), cdc)
-                };
+        let mut cdc = vec![];
+        let _global_guard = self.index_lock.read();
+        if let Some(target_node_entry) = self.index.lower_bound(Bound::Included(value)) {
+            let mut node_guard = target_node_entry.value().lock_arc();
+            let old_max = node_guard.max().cloned();
+            let deleted = NodeLike::delete(&mut *node_guard, value);
+            if deleted.is_none() {
+                return (None, cdc);
             }
+            let (deleted, idx) = deleted.expect("should be ok as checked before");
 
-            break;
+            let operation = if node_guard.len() > 0 {
+                #[cfg(feature = "cdc")]
+                {
+                    let node_element_removal = ChangeEvent::RemoveAt {
+                        // is correct as node is locked and current thread is the only that can
+                        // fetch event_id, so events for this node will have monotonic id's.
+                        event_id: self.event_id.fetch_add(1, Ordering::AcqRel).into(),
+                        max_value: old_max.clone().expect("Max value should exist as Node is not empty"),
+                        value: deleted.clone(),
+                        index: idx,
+                    };
+                    cdc.push(node_element_removal);
+                }
+
+                if old_max.as_ref() == node_guard.max() {
+                    return (Some(deleted), cdc);
+                }
+
+                Some(Operation::UpdateMax(
+                    target_node_entry.value().clone(),
+                    old_max.unwrap(),
+                ))
+            } else {
+                Some(Operation::MakeUnreachable(
+                    target_node_entry.value().clone(),
+                    old_max.unwrap(),
+                ))
+            };
+
+            drop(node_guard);
+            drop(_global_guard);
+
+            let _global_guard = self.index_lock.write();
+
+            return if let Ok((_, value_cdc)) = operation.unwrap().commit(&self.index) {
+                #[cfg(feature = "cdc")]
+                {
+                    for unassigned_event in value_cdc {
+                        let event_id = self.event_id.fetch_add(1, Ordering::AcqRel).into();
+                        cdc.push(unassigned_event.assign_id(event_id));
+                    }
+                }
+                (Some(deleted), cdc)
+            } else {
+                (Some(deleted), cdc)
+            };
         }
-
         (None, vec![])
     }
     /// If the set contains an element equal to the value, removes it from the
@@ -455,7 +448,7 @@ where
         Q: Ord + ?Sized,
     {
         let _global_guard = self.index_lock.read();
-        match self.index.lower_bound(std::ops::Bound::Included(&value)) {
+        match self.index.lower_bound(std::ops::Bound::Included(value)) {
             Some(entry) => Some(entry.value().clone()),
             None => self
                 .index
@@ -512,6 +505,9 @@ where
     }
     pub fn len(&self) -> usize {
         self.index.iter().map(|node| node.value().lock().len()).sum()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
     pub fn capacity(&self) -> usize {
         self.index
@@ -629,7 +625,7 @@ where
                                 .lock_arc(),
                         );
                         self.current_front_node_iter = Some(unsafe {
-                            std::mem::transmute(
+                            std::mem::transmute::<std::slice::Iter<'_, T>, std::slice::Iter<'a, T>>(
                                 self.current_front_node_guard
                                     .as_ref()
                                     .expect("was just set before")
@@ -686,7 +682,7 @@ where
                                     .lock_arc(),
                             );
                             self.current_front_node_iter = Some(unsafe {
-                                std::mem::transmute(
+                                std::mem::transmute::<std::slice::Iter<'_, T>, std::slice::Iter<'a, T>>(
                                     self.current_front_node_guard
                                         .as_ref()
                                         .expect("was just set before")
@@ -715,7 +711,7 @@ where
                         .lock_arc(),
                 );
                 self.current_front_node_iter = Some(unsafe {
-                    std::mem::transmute(
+                    std::mem::transmute::<std::slice::Iter<'_, T>, std::slice::Iter<'a, T>>(
                         self.current_front_node_guard
                             .as_ref()
                             .expect("was just set before")
@@ -773,7 +769,7 @@ where
                         self.current_back_node_guard =
                             Some(self.current_back_node.as_ref().expect("was just set before").lock_arc());
                         self.current_back_node_iter = Some(unsafe {
-                            std::mem::transmute(
+                            std::mem::transmute::<std::slice::Iter<'_, T>, std::slice::Iter<'a, T>>(
                                 self.current_back_node_guard
                                     .as_ref()
                                     .expect("was just set before")
@@ -825,7 +821,7 @@ where
                             self.current_back_node_guard =
                                 Some(self.current_back_node.as_ref().expect("was just set before").lock_arc());
                             self.current_back_node_iter = Some(unsafe {
-                                std::mem::transmute(
+                                std::mem::transmute::<std::slice::Iter<'_, T>, std::slice::Iter<'a, T>>(
                                     self.current_back_node_guard
                                         .as_ref()
                                         .expect("was just set before")
@@ -850,7 +846,7 @@ where
                 self.current_back_node_guard =
                     Some(self.current_back_node.as_ref().expect("was just set before").lock_arc());
                 self.current_back_node_iter = Some(unsafe {
-                    std::mem::transmute(
+                    std::mem::transmute::<std::slice::Iter<'_, T>, std::slice::Iter<'a, T>>(
                         self.current_back_node_guard
                             .as_ref()
                             .expect("was just set before")
@@ -935,16 +931,14 @@ where
                 drop(front_guard);
 
                 front_value
-            } else {
-                if let Some(pre_front_entry) = front_entry.prev() {
-                    let pre_front_guard = pre_front_entry.value().lock_arc();
-                    let front_value = pre_front_guard.iter().last().cloned();
-                    drop(pre_front_guard);
+            } else if let Some(pre_front_entry) = front_entry.prev() {
+                let pre_front_guard = pre_front_entry.value().lock_arc();
+                let front_value = pre_front_guard.iter().last().cloned();
+                drop(pre_front_guard);
 
-                    front_value
-                } else {
-                    None
-                }
+                front_value
+            } else {
+                None
             }
         } else {
             None
@@ -969,16 +963,14 @@ where
                 drop(back_guard);
 
                 back_value
-            } else {
-                if let Some(prev_back_entry) = back_entry.next() {
-                    let prev_back_guard = prev_back_entry.value().lock_arc();
-                    let back_value = prev_back_guard.iter().next().cloned();
-                    drop(prev_back_guard);
+            } else if let Some(prev_back_entry) = back_entry.next() {
+                let prev_back_guard = prev_back_entry.value().lock_arc();
+                let back_value = prev_back_guard.iter().next().cloned();
+                drop(prev_back_guard);
 
-                    back_value
-                } else {
-                    None
-                }
+                back_value
+            } else {
+                None
             }
         } else {
             None
@@ -1179,16 +1171,14 @@ where
                         }
 
                         guard = Some(new_guard);
-                    } else {
-                        if let Some((len, position)) = potential_front_entry_guard
-                            .as_ref()
-                            .and_then(|g| Some((g.len(), g.rank(end_bound, true))))
-                        {
-                            if let Some(position) = position {
-                                back_position = position;
-                            } else {
-                                back_position = len;
-                            }
+                    } else if let Some((len, position)) = potential_front_entry_guard
+                        .as_ref()
+                        .map(|g| (g.len(), g.rank(end_bound, true)))
+                    {
+                        if let Some(position) = position {
+                            back_position = position;
+                        } else {
+                            back_position = len;
                         }
                     }
                 }
@@ -1202,7 +1192,7 @@ where
         if let Some(mut front_entry_guard) = potential_front_entry_guard {
             let front_entry = potential_front_entry.unwrap();
             // But no back entry
-            if let None = potential_back_entry_guard {
+            if potential_back_entry_guard.is_none() {
                 // Then we drain the front entry
                 let adjusted_back_position = {
                     if potential_front_position > potential_back_position {
@@ -1223,21 +1213,15 @@ where
                 // Otherwise we insert it again with a new max
                 let new_max = front_entry_guard.last().unwrap().clone();
                 self.index.insert(new_max, old_entry_value);
-
-                return;
             } else if let Some(mut back_entry_guard) = potential_back_entry_guard {
                 let back_entry = potential_back_entry.unwrap();
                 // Otherwise we remove every single node between them
-                loop {
-                    if let Some(next_entry) = front_entry.next() {
-                        if next_entry.key().eq(back_entry.key()) {
-                            break;
-                        }
-
-                        next_entry.remove();
-                    } else {
+                while let Some(next_entry) = front_entry.next() {
+                    if next_entry.key().eq(back_entry.key()) {
                         break;
                     }
+
+                    next_entry.remove();
                 }
 
                 // And then trim the front from the left
@@ -1257,7 +1241,6 @@ where
                 }
 
                 // And that's it
-                return;
             }
         }
     }
@@ -1294,10 +1277,10 @@ mod tests {
 
         let expected_values = Arc::new(Mutex::new(HashSet::new()));
 
-        for thread_idx in 0..num_threads {
+        for thread_data in test_data.iter().take(num_threads) {
             let set_clone = Arc::clone(&set);
             let expected_values = Arc::clone(&expected_values);
-            let thread_data = test_data[thread_idx].clone();
+            let thread_data = thread_data.clone();
 
             let handle = thread::spawn(move || {
                 for (operation, value) in thread_data {
@@ -1444,21 +1427,13 @@ mod tests {
 
     #[test]
     fn test_iterating_over_blocks() {
-        let btree = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 10)).into_iter());
+        let btree = BTreeSet::from_iter(0..(DEFAULT_INNER_SIZE + 10));
         assert_eq!(btree.iter().count(), (0..(DEFAULT_INNER_SIZE + 10)).count());
-        let start = btree
-            .range(0..DEFAULT_INNER_SIZE)
-            .into_iter()
-            .cloned()
-            .collect::<Vec<_>>();
+        let start = btree.range(0..DEFAULT_INNER_SIZE).cloned().collect::<Vec<_>>();
 
         assert_eq!(start, (0..DEFAULT_INNER_SIZE).collect::<Vec<_>>());
         assert_eq!(
-            btree
-                .range(0..=DEFAULT_INNER_SIZE)
-                .into_iter()
-                .cloned()
-                .collect::<Vec<_>>(),
+            btree.range(0..=DEFAULT_INNER_SIZE).cloned().collect::<Vec<_>>(),
             (0..=DEFAULT_INNER_SIZE).collect::<Vec<_>>()
         );
         assert_eq!(
@@ -1561,7 +1536,6 @@ mod tests {
 
         // This range exceeds the size of the tree
         btree.remove_range(DEFAULT_INNER_SIZE * 3..DEFAULT_INNER_SIZE * 4);
-        let expected_len = expected_len;
         let actual_len = btree.len();
         assert_eq!(expected_len, actual_len);
 

--- a/src/core/multipair.rs
+++ b/src/core/multipair.rs
@@ -2,9 +2,9 @@ use std::fmt::Debug;
 use std::{borrow::Borrow, mem::MaybeUninit};
 
 use core::cmp::Ordering;
+use fastrand;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use fastrand;
 
 use crate::core::pair::Pair;
 
@@ -18,13 +18,25 @@ pub struct MultiPair<K, V> {
 
 impl<K: Ord, V: PartialEq> MultiPair<K, V> {
     pub fn new(key: K, value: V) -> Self {
-        Self { key, value, discriminator: fastrand::u64(..) }
+        Self {
+            key,
+            value,
+            discriminator: fastrand::u64(..),
+        }
     }
     pub fn with_infimum(key: K) -> Self {
-        Self { key, value: unsafe { MaybeUninit::uninit().assume_init() }, discriminator: INFIMUM }
+        Self {
+            key,
+            value: unsafe { MaybeUninit::uninit().assume_init() },
+            discriminator: INFIMUM,
+        }
     }
     pub fn with_supremum(key: K) -> Self {
-        Self { key, value: unsafe { MaybeUninit::uninit().assume_init() }, discriminator: SUPREMUM }
+        Self {
+            key,
+            value: unsafe { MaybeUninit::uninit().assume_init() },
+            discriminator: SUPREMUM,
+        }
     }
 }
 
@@ -43,7 +55,9 @@ impl<K: Ord, V: PartialEq> Ord for MultiPair<K, V> {
     fn cmp(&self, other: &Self) -> Ordering {
         match self.key.cmp(&other.key) {
             Ordering::Equal => {
-                if (self.discriminator == INFIMUM || other.discriminator == INFIMUM) || (self.discriminator == SUPREMUM || other.discriminator == SUPREMUM) {
+                if (self.discriminator == INFIMUM || other.discriminator == INFIMUM)
+                    || (self.discriminator == SUPREMUM || other.discriminator == SUPREMUM)
+                {
                     return self.discriminator.cmp(&other.discriminator);
                 }
 
@@ -52,7 +66,7 @@ impl<K: Ord, V: PartialEq> Ord for MultiPair<K, V> {
                 }
 
                 self.discriminator.cmp(&other.discriminator)
-            },
+            }
             ord => ord,
         }
     }
@@ -114,22 +128,22 @@ mod test {
         let p1 = MultiPair::new(1, "a");
         let p2 = MultiPair::new(1, "b");
         let p3 = MultiPair::new(2, "c");
-     
+
         NodeLike::insert(&mut vec, p1.clone());
         NodeLike::insert(&mut vec, p2.clone());
-        assert_eq!(vec.len(), 2); 
+        assert_eq!(vec.len(), 2);
 
         NodeLike::insert(&mut vec, p1.clone());
         assert_eq!(vec.len(), 2);
-     
+
         NodeLike::insert(&mut vec, p3.clone());
         assert_eq!(vec.len(), 3);
-     }
+    }
 
-     #[test]
-     fn range_bounds() {
+    #[test]
+    fn range_bounds() {
         let mut vec = Vec::new();
-    
+
         let p1a = MultiPair::new(1, "a");
         let p1b = MultiPair::new(1, "b");
         let p1c = MultiPair::new(1, "c");
@@ -153,7 +167,10 @@ mod test {
         NodeLike::insert(&mut vec, p3c.clone());
         assert_eq!(vec.len(), 10);
 
-        let start_1 = vec.rank(Included(&MultiPair::with_infimum(1)), true).or_else(|| Some(0)).unwrap();
+        let start_1 = vec
+            .rank(Included(&MultiPair::with_infimum(1)), true)
+            .or_else(|| Some(0))
+            .unwrap();
         let end_1 = vec.rank(Excluded(&MultiPair::with_supremum(1)), true).unwrap();
         let range_1 = &vec[start_1..=end_1];
         assert_eq!(range_1.len(), 3);
@@ -185,5 +202,5 @@ mod test {
         let range_4 = &vec[start_4..=end_4];
         assert_eq!(range_4.len(), 1);
         assert!(range_4.contains(&p4a));
-     }
+    }
 }

--- a/src/core/multipair.rs
+++ b/src/core/multipair.rs
@@ -1,189 +1,42 @@
-use std::fmt::Debug;
-use std::{borrow::Borrow, mem::MaybeUninit};
+use crate::cdc::change::ChangeEvent;
+use crate::concurrent::set::BTreeSet;
+use crate::core::node::NodeLike;
 
-use core::cmp::Ordering;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use fastrand;
+pub mod ord;
+pub mod random;
 
-use crate::core::pair::Pair;
+pub use ord::OrdMultiPair;
+pub use random::RandomMultiPair;
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, Hash)]
-pub struct MultiPair<K, V> {
-    pub key: K,
-    pub value: V,
-    pub discriminator: u64,
+pub type MultiPair<K, V> = RandomMultiPair<K, V>;
+
+/// Common contract for key-value pairs stored by `BTreeMultiMap`.
+///
+/// Implementations must order entries by key first: entries with the same key
+/// must form one contiguous range, while their representation may refine the
+/// order within that range.
+pub trait MultiPairLike<K, V>: Into<(K, V)> + Ord {
+    fn new(key: K, value: V) -> Self;
+    fn key(&self) -> &K;
+    fn value(&self) -> &V;
 }
 
-impl<K: Ord, V: PartialEq> MultiPair<K, V> {
-    pub fn new(key: K, value: V) -> Self {
-        Self { key, value, discriminator: fastrand::u64(..) }
-    }
-    pub fn with_infimum(key: K) -> Self {
-        Self { key, value: unsafe { MaybeUninit::uninit().assume_init() }, discriminator: INFIMUM }
-    }
-    pub fn with_supremum(key: K) -> Self {
-        Self { key, value: unsafe { MaybeUninit::uninit().assume_init() }, discriminator: SUPREMUM }
-    }
-}
-
-impl<K: Ord, V: PartialEq> Eq for MultiPair<K, V> {}
-
-impl<K: Ord, V: PartialEq> PartialEq<Self> for MultiPair<K, V> {
-    fn eq(&self, other: &Self) -> bool {
-        self.key.eq(&other.key) && self.value.eq(&other.value)
-    }
-}
-
-const INFIMUM: u64 = 0;
-const SUPREMUM: u64 = u64::MAX;
-
-impl<K: Ord, V: PartialEq> Ord for MultiPair<K, V> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match self.key.cmp(&other.key) {
-            Ordering::Equal => {
-                if (self.discriminator == INFIMUM || other.discriminator == INFIMUM) || (self.discriminator == SUPREMUM || other.discriminator == SUPREMUM) {
-                    return self.discriminator.cmp(&other.discriminator);
-                }
-
-                if self.value.eq(&other.value) {
-                    return Ordering::Equal;
-                }
-
-                self.discriminator.cmp(&other.discriminator)
-            },
-            ord => ord,
-        }
-    }
-}
-
-impl<K: Ord, V: PartialEq> PartialOrd for MultiPair<K, V> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<K: Ord, V: PartialEq> Borrow<K> for MultiPair<K, V> {
-    fn borrow(&self) -> &K {
-        &self.key
-    }
-}
-
-impl<K: Ord, V: PartialEq> From<Pair<K, V>> for MultiPair<K, V> {
-    fn from(pair: Pair<K, V>) -> Self {
-        MultiPair {
-            key: pair.key,
-            value: pair.value,
-            discriminator: fastrand::u64(..),
-        }
-    }
-}
-
-impl<K: Ord, V: PartialEq> From<MultiPair<K, V>> for Pair<K, V> {
-    fn from(pair: MultiPair<K, V>) -> Self {
-        Pair {
-            key: pair.key,
-            value: pair.value,
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::core::node::NodeLike;
-    use std::ops::Bound::*;
-
-    #[test]
-    fn borrow_test() {
-        let pair = MultiPair::new(1usize, 2usize);
-        assert_eq!(<MultiPair<usize, usize> as Borrow<usize>>::borrow(&pair), &1usize);
+/// Pair-specific exact-removal strategy used by `BTreeMultiMap`.
+pub trait MultiPairRemoveHelper<K, V> {
+    fn remove_from<Node>(set: &BTreeSet<Self, Node>, key: &K, value: &V) -> Option<(K, V)>
+    where
+        Self: Ord + Clone + 'static,
+        Node: NodeLike<Self> + Send + 'static,
+    {
+        Self::remove_cdc_from(set, key, value).0
     }
 
-    #[test]
-    fn eq_test() {
-        let pair_one = MultiPair::new(1usize, 2usize);
-        let pair_two = MultiPair::new(1usize, 3usize);
-        assert_ne!(pair_one, pair_two);
-    }
-
-    #[test]
-    fn node_like() {
-        let mut vec = Vec::new();
-        let p1 = MultiPair::new(1, "a");
-        let p2 = MultiPair::new(1, "b");
-        let p3 = MultiPair::new(2, "c");
-     
-        NodeLike::insert(&mut vec, p1.clone());
-        NodeLike::insert(&mut vec, p2.clone());
-        assert_eq!(vec.len(), 2); 
-
-        NodeLike::insert(&mut vec, p1.clone());
-        assert_eq!(vec.len(), 2);
-     
-        NodeLike::insert(&mut vec, p3.clone());
-        assert_eq!(vec.len(), 3);
-     }
-
-     #[test]
-     fn range_bounds() {
-        let mut vec = Vec::new();
-    
-        let p1a = MultiPair::new(1, "a");
-        let p1b = MultiPair::new(1, "b");
-        let p1c = MultiPair::new(1, "c");
-        let p2a = MultiPair::new(2, "a");
-        let p2b = MultiPair::new(2, "b");
-        let p3a = MultiPair::new(3, "a");
-        let p3b = MultiPair::new(3, "b");
-        let p3c = MultiPair::new(3, "c");
-        let p3d = MultiPair::new(3, "d");
-        let p4a = MultiPair::new(4, "a");
-
-        NodeLike::insert(&mut vec, p4a.clone());
-        NodeLike::insert(&mut vec, p1a.clone());
-        NodeLike::insert(&mut vec, p1c.clone());
-        NodeLike::insert(&mut vec, p1b.clone());
-        NodeLike::insert(&mut vec, p2b.clone());
-        NodeLike::insert(&mut vec, p2a.clone());
-        NodeLike::insert(&mut vec, p3a.clone());
-        NodeLike::insert(&mut vec, p3b.clone());
-        NodeLike::insert(&mut vec, p3d.clone());
-        NodeLike::insert(&mut vec, p3c.clone());
-        assert_eq!(vec.len(), 10);
-
-        let start_1 = vec.rank(Included(&MultiPair::with_infimum(1)), true).or_else(|| Some(0)).unwrap();
-        let end_1 = vec.rank(Excluded(&MultiPair::with_supremum(1)), true).unwrap();
-        let range_1 = &vec[start_1..=end_1];
-        assert_eq!(range_1.len(), 3);
-        assert!(range_1.contains(&p1a));
-        assert!(range_1.contains(&p1b));
-        assert!(range_1.contains(&p1c));
-
-        let end_2 = vec.rank(Excluded(&MultiPair::with_supremum(2)), true).unwrap();
-        let range_2 = &vec[start_1..=end_2];
-        assert_eq!(range_2.len(), 5);
-        assert!(range_2.contains(&p1a));
-        assert!(range_2.contains(&p1b));
-        assert!(range_2.contains(&p1c));
-        assert!(range_2.contains(&p2a));
-        assert!(range_2.contains(&p2b));
-        assert_ne!(range_2.contains(&p3a), true);
-
-        let start_3 = vec.rank(Included(&MultiPair::with_infimum(3)), true).unwrap() + 1;
-        let end_3 = vec.rank(Excluded(&MultiPair::with_supremum(3)), true).unwrap();
-        let range_3 = &vec[start_3..=end_3];
-        assert_eq!(range_3.len(), 4);
-        assert!(range_3.contains(&p3a));
-        assert!(range_3.contains(&p3b));
-        assert!(range_3.contains(&p3c));
-        assert!(range_3.contains(&p3d));
-
-        let start_4 = vec.rank(Included(&MultiPair::with_infimum(4)), true).unwrap() + 1;
-        let end_4 = vec.rank(Excluded(&MultiPair::with_supremum(4)), true).unwrap();
-        let range_4 = &vec[start_4..=end_4];
-        assert_eq!(range_4.len(), 1);
-        assert!(range_4.contains(&p4a));
-     }
+    fn remove_cdc_from<Node>(
+        set: &BTreeSet<Self, Node>,
+        key: &K,
+        value: &V,
+    ) -> (Option<(K, V)>, Vec<ChangeEvent<Self>>)
+    where
+        Self: Ord + Clone + 'static,
+        Node: NodeLike<Self> + Send + 'static;
 }

--- a/src/core/multipair.rs
+++ b/src/core/multipair.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::pair::Pair;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, Hash)]
+#[derive(Debug, Default, Clone)]
 pub struct MultiPair<K, V> {
     pub key: K,
     pub value: V,
@@ -24,6 +24,9 @@ impl<K: Ord, V: PartialEq> MultiPair<K, V> {
             discriminator: fastrand::u64(..),
         }
     }
+    // SAFETY: The `value` field is never read for sentinel values - only `key` and
+    // `discriminator` are used for ordering.
+    #[allow(clippy::uninit_assumed_init)]
     pub fn with_infimum(key: K) -> Self {
         Self {
             key,
@@ -31,6 +34,9 @@ impl<K: Ord, V: PartialEq> MultiPair<K, V> {
             discriminator: INFIMUM,
         }
     }
+    // SAFETY: The `value` field is never read for sentinel values - only `key` and
+    // `discriminator` are used for ordering.
+    #[allow(clippy::uninit_assumed_init)]
     pub fn with_supremum(key: K) -> Self {
         Self {
             key,
@@ -75,6 +81,17 @@ impl<K: Ord, V: PartialEq> Ord for MultiPair<K, V> {
 impl<K: Ord, V: PartialEq> PartialOrd for MultiPair<K, V> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl<K, V> std::hash::Hash for MultiPair<K, V>
+where
+    K: std::hash::Hash,
+    V: std::hash::Hash,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
+        self.value.hash(state);
     }
 }
 
@@ -167,10 +184,7 @@ mod test {
         NodeLike::insert(&mut vec, p3c.clone());
         assert_eq!(vec.len(), 10);
 
-        let start_1 = vec
-            .rank(Included(&MultiPair::with_infimum(1)), true)
-            .or_else(|| Some(0))
-            .unwrap();
+        let start_1 = vec.rank(Included(&MultiPair::with_infimum(1)), true).unwrap_or(0);
         let end_1 = vec.rank(Excluded(&MultiPair::with_supremum(1)), true).unwrap();
         let range_1 = &vec[start_1..=end_1];
         assert_eq!(range_1.len(), 3);
@@ -186,7 +200,7 @@ mod test {
         assert!(range_2.contains(&p1c));
         assert!(range_2.contains(&p2a));
         assert!(range_2.contains(&p2b));
-        assert_ne!(range_2.contains(&p3a), true);
+        assert!(!range_2.contains(&p3a));
 
         let start_3 = vec.rank(Included(&MultiPair::with_infimum(3)), true).unwrap() + 1;
         let end_3 = vec.rank(Excluded(&MultiPair::with_supremum(3)), true).unwrap();

--- a/src/core/multipair/ord.rs
+++ b/src/core/multipair/ord.rs
@@ -1,0 +1,111 @@
+use std::borrow::Borrow;
+use std::fmt::Debug;
+
+use core::cmp::Ordering;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::cdc::change::ChangeEvent;
+use crate::concurrent::set::BTreeSet;
+use crate::core::node::NodeLike;
+use crate::core::pair::Pair;
+
+use super::{MultiPairLike, MultiPairRemoveHelper};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone, Hash)]
+pub struct OrdMultiPair<K, V> {
+    pub key: K,
+    pub value: V,
+}
+
+impl<K, V> OrdMultiPair<K, V> {
+    pub fn new(key: K, value: V) -> Self {
+        Self { key, value }
+    }
+}
+
+impl<K: Ord, V: Ord> Eq for OrdMultiPair<K, V> {}
+
+impl<K: Ord, V: Ord> PartialEq<Self> for OrdMultiPair<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key.eq(&other.key) && self.value.eq(&other.value)
+    }
+}
+
+impl<K: Ord, V: Ord> Ord for OrdMultiPair<K, V> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key.cmp(&other.key).then(self.value.cmp(&other.value))
+    }
+}
+
+impl<K: Ord, V: Ord> PartialOrd for OrdMultiPair<K, V> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K, V> Borrow<K> for OrdMultiPair<K, V> {
+    fn borrow(&self) -> &K {
+        &self.key
+    }
+}
+
+impl<K: Ord, V: Ord> MultiPairLike<K, V> for OrdMultiPair<K, V> {
+    fn new(key: K, value: V) -> Self {
+        Self::new(key, value)
+    }
+
+    fn key(&self) -> &K {
+        &self.key
+    }
+
+    fn value(&self) -> &V {
+        &self.value
+    }
+}
+
+impl<K, V> From<Pair<K, V>> for OrdMultiPair<K, V> {
+    fn from(pair: Pair<K, V>) -> Self {
+        OrdMultiPair {
+            key: pair.key,
+            value: pair.value,
+        }
+    }
+}
+
+impl<K, V> From<OrdMultiPair<K, V>> for Pair<K, V> {
+    fn from(pair: OrdMultiPair<K, V>) -> Self {
+        Pair {
+            key: pair.key,
+            value: pair.value,
+        }
+    }
+}
+
+impl<K, V> From<OrdMultiPair<K, V>> for (K, V) {
+    fn from(pair: OrdMultiPair<K, V>) -> Self {
+        (pair.key, pair.value)
+    }
+}
+
+impl<K, V> MultiPairRemoveHelper<K, V> for OrdMultiPair<K, V>
+where
+    K: Debug + Send + Ord + Clone + 'static,
+    V: Debug + Send + Ord + Clone + 'static,
+{
+    fn remove_cdc_from<Node>(
+        set: &BTreeSet<Self, Node>,
+        key: &K,
+        value: &V,
+    ) -> (Option<(K, V)>, Vec<ChangeEvent<Self>>)
+    where
+        Self: Ord + Clone + 'static,
+        Node: NodeLike<Self> + Send + 'static,
+    {
+        let pair_to_remove = OrdMultiPair::new(key.clone(), value.clone());
+        let (res, evs) = set.remove_cdc(&pair_to_remove);
+
+        (res.map(Into::into), evs)
+    }
+}

--- a/src/core/multipair/random.rs
+++ b/src/core/multipair/random.rs
@@ -1,0 +1,225 @@
+use std::borrow::Borrow;
+use std::fmt::Debug;
+use std::ops::Bound;
+
+use core::cmp::Ordering;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::cdc::change::ChangeEvent;
+use crate::concurrent::set::BTreeSet;
+use crate::core::node::NodeLike;
+use crate::core::pair::Pair;
+
+use super::{MultiPairLike, MultiPairRemoveHelper};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone, Hash)]
+pub struct RandomMultiPair<K, V> {
+    pub key: K,
+    pub value: V,
+    pub discriminator: u64,
+}
+
+impl<K, V> RandomMultiPair<K, V> {
+    pub fn new(key: K, value: V) -> Self {
+        Self { key, value, discriminator: fastrand::u64(..) }
+    }
+
+}
+
+impl<K: Ord, V: PartialEq> Eq for RandomMultiPair<K, V> {}
+
+impl<K: Ord, V: PartialEq> PartialEq<Self> for RandomMultiPair<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key.eq(&other.key) && self.value.eq(&other.value)
+    }
+}
+
+impl<K: Ord, V: PartialEq> Ord for RandomMultiPair<K, V> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.key.cmp(&other.key) {
+            Ordering::Equal if self.value.eq(&other.value) => Ordering::Equal,
+            Ordering::Equal => self.discriminator.cmp(&other.discriminator),
+            ord => ord,
+        }
+    }
+}
+
+impl<K: Ord, V: PartialEq> PartialOrd for RandomMultiPair<K, V> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K, V> Borrow<K> for RandomMultiPair<K, V> {
+    fn borrow(&self) -> &K {
+        &self.key
+    }
+}
+
+impl<K: Ord, V: PartialEq> MultiPairLike<K, V> for RandomMultiPair<K, V> {
+    fn new(key: K, value: V) -> Self {
+        Self::new(key, value)
+    }
+
+    fn key(&self) -> &K {
+        &self.key
+    }
+
+    fn value(&self) -> &V {
+        &self.value
+    }
+}
+
+impl<K, V> From<Pair<K, V>> for RandomMultiPair<K, V> {
+    fn from(pair: Pair<K, V>) -> Self {
+        RandomMultiPair {
+            key: pair.key,
+            value: pair.value,
+            discriminator: fastrand::u64(..),
+        }
+    }
+}
+
+impl<K, V> From<RandomMultiPair<K, V>> for Pair<K, V> {
+    fn from(pair: RandomMultiPair<K, V>) -> Self {
+        Pair {
+            key: pair.key,
+            value: pair.value,
+        }
+    }
+}
+
+impl<K, V> From<RandomMultiPair<K, V>> for (K, V) {
+    fn from(pair: RandomMultiPair<K, V>) -> Self {
+        (pair.key, pair.value)
+    }
+}
+
+impl<K, V> MultiPairRemoveHelper<K, V> for RandomMultiPair<K, V>
+where
+    K: Debug + Send + Ord + Clone + 'static,
+    V: Debug + Send + Clone + PartialEq + 'static,
+{
+    fn remove_cdc_from<Node>(
+        set: &BTreeSet<Self, Node>,
+        key: &K,
+        value: &V,
+    ) -> (Option<(K, V)>, Vec<ChangeEvent<Self>>)
+    where
+        Self: Ord + Clone + 'static,
+        Node: NodeLike<Self> + Send + 'static,
+    {
+        let pair_to_remove = set
+            .range::<K, _>((Bound::Included(key), Bound::Included(key)))
+            .find(|pair| pair.key == *key && pair.value == *value)
+            .cloned();
+
+        if let Some(pair_to_remove) = pair_to_remove {
+            let (res, evs) = set.remove_cdc(&pair_to_remove);
+            return (res.map(Into::into), evs);
+        }
+
+        (None, vec![])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::core::node::NodeLike;
+    use std::ops::Bound::*;
+
+    #[test]
+    fn borrow_test() {
+        let pair = RandomMultiPair::new(1usize, 2usize);
+        assert_eq!(<RandomMultiPair<usize, usize> as Borrow<usize>>::borrow(&pair), &1usize);
+    }
+
+    #[test]
+    fn eq_test() {
+        let pair_one = RandomMultiPair::new(1usize, 2usize);
+        let pair_two = RandomMultiPair::new(1usize, 3usize);
+        assert_ne!(pair_one, pair_two);
+    }
+
+    #[test]
+    fn node_like() {
+        let mut vec = Vec::new();
+        let p1 = RandomMultiPair::new(1, "a");
+        let p2 = RandomMultiPair::new(1, "b");
+        let p3 = RandomMultiPair::new(2, "c");
+     
+        NodeLike::insert(&mut vec, p1.clone());
+        NodeLike::insert(&mut vec, p2.clone());
+        assert_eq!(vec.len(), 2); 
+
+        NodeLike::insert(&mut vec, p1.clone());
+        assert_eq!(vec.len(), 2);
+     
+        NodeLike::insert(&mut vec, p3.clone());
+        assert_eq!(vec.len(), 3);
+     }
+
+     #[test]
+     fn range_bounds() {
+        let mut vec = Vec::new();
+    
+        let p1a = RandomMultiPair::new(1, "a");
+        let p1b = RandomMultiPair::new(1, "b");
+        let p1c = RandomMultiPair::new(1, "c");
+        let p2a = RandomMultiPair::new(2, "a");
+        let p2b = RandomMultiPair::new(2, "b");
+        let p3a = RandomMultiPair::new(3, "a");
+        let p3b = RandomMultiPair::new(3, "b");
+        let p3c = RandomMultiPair::new(3, "c");
+        let p3d = RandomMultiPair::new(3, "d");
+        let p4a = RandomMultiPair::new(4, "a");
+
+        NodeLike::insert(&mut vec, p4a.clone());
+        NodeLike::insert(&mut vec, p1a.clone());
+        NodeLike::insert(&mut vec, p1c.clone());
+        NodeLike::insert(&mut vec, p1b.clone());
+        NodeLike::insert(&mut vec, p2b.clone());
+        NodeLike::insert(&mut vec, p2a.clone());
+        NodeLike::insert(&mut vec, p3a.clone());
+        NodeLike::insert(&mut vec, p3b.clone());
+        NodeLike::insert(&mut vec, p3d.clone());
+        NodeLike::insert(&mut vec, p3c.clone());
+        assert_eq!(vec.len(), 10);
+
+        let start_1 = vec.rank(Included(&1), true).map_or(0, |rank| rank + 1);
+        let end_1 = vec.rank(Excluded(&1), true).unwrap();
+        let range_1 = &vec[start_1..=end_1];
+        assert_eq!(range_1.len(), 3);
+        assert!(range_1.contains(&p1a));
+        assert!(range_1.contains(&p1b));
+        assert!(range_1.contains(&p1c));
+
+        let end_2 = vec.rank(Excluded(&2), true).unwrap();
+        let range_2 = &vec[start_1..=end_2];
+        assert_eq!(range_2.len(), 5);
+        assert!(range_2.contains(&p1a));
+        assert!(range_2.contains(&p1b));
+        assert!(range_2.contains(&p1c));
+        assert!(range_2.contains(&p2a));
+        assert!(range_2.contains(&p2b));
+        assert_ne!(range_2.contains(&p3a), true);
+
+        let start_3 = vec.rank(Included(&3), true).unwrap() + 1;
+        let end_3 = vec.rank(Excluded(&3), true).unwrap();
+        let range_3 = &vec[start_3..=end_3];
+        assert_eq!(range_3.len(), 4);
+        assert!(range_3.contains(&p3a));
+        assert!(range_3.contains(&p3b));
+        assert!(range_3.contains(&p3c));
+        assert!(range_3.contains(&p3d));
+
+        let start_4 = vec.rank(Included(&4), true).unwrap() + 1;
+        let end_4 = vec.rank(Excluded(&4), true).unwrap();
+        let range_4 = &vec[start_4..=end_4];
+        assert_eq!(range_4.len(), 1);
+        assert!(range_4.contains(&p4a));
+     }
+}

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -40,7 +40,9 @@ pub trait NodeLike<T: Ord> {
     #[allow(dead_code)]
     fn min(&self) -> Option<&T>;
     #[allow(dead_code)]
-    fn iter<'a>(&'a self) -> std::slice::Iter<'a, T> where T: 'a;
+    fn iter<'a>(&'a self) -> std::slice::Iter<'a, T>
+    where
+        T: 'a;
 }
 
 #[inline]
@@ -85,7 +87,7 @@ where
 {
     match bound {
         // If the bound is unbounded, then no skipping is needed
-        std::ops::Bound::Unbounded => { None }
+        std::ops::Bound::Unbounded => None,
         std::ops::Bound::Included(value) | std::ops::Bound::Excluded(value) => {
             let mut positions_to_skip = -1;
             let iter = if forward {
@@ -99,9 +101,12 @@ where
                     for item in iter {
                         match item.borrow().cmp(&value) {
                             Ordering::Less => positions_to_skip += 1,
-                                Ordering::Equal => match bound {
+                            Ordering::Equal => match bound {
                                 std::ops::Bound::Included(_) => break,
-                                std::ops::Bound::Excluded(_) => { positions_to_skip += 1; break },
+                                std::ops::Bound::Excluded(_) => {
+                                    positions_to_skip += 1;
+                                    break;
+                                }
                                 _ => unreachable!(),
                             },
                             Ordering::Greater => break,
@@ -114,7 +119,10 @@ where
                             Ordering::Greater => positions_to_skip += 1,
                             Ordering::Equal => match bound {
                                 std::ops::Bound::Included(_) => break,
-                                std::ops::Bound::Excluded(_) => { positions_to_skip += 1; break },
+                                std::ops::Bound::Excluded(_) => {
+                                    positions_to_skip += 1;
+                                    break;
+                                }
                                 _ => unreachable!(),
                             },
                             Ordering::Less => break,
@@ -227,7 +235,8 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     }
     #[inline]
     fn iter<'a>(&'a self) -> std::slice::Iter<'a, T>
-    where T: 'a
+    where
+        T: 'a,
     {
         self.deref().iter()
     }
@@ -244,33 +253,98 @@ mod tests {
         assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, true), None);
         assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, false), None);
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), true), Some(1));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), true), Some(3));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), true), Some(4));
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), true),
+            Some(1)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), true),
+            Some(3)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), true),
+            Some(4)
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), true), Some(0));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), true), Some(2));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), true), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), true), Some(4));
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), true),
+            Some(0)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), true),
+            Some(2)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), true),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), true),
+            Some(4)
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), false), Some(3));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), false), Some(1));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), false), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), false),
+            Some(3)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), false),
+            Some(1)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), false),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), false),
+            None
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), false), Some(2));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), false), Some(0));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), false),
+            Some(2)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), false),
+            Some(0)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), false),
+            None
+        );
 
         let empty: Vec<i32> = vec![];
-        assert_eq!(compute_positions_to_skip(&empty, std::ops::Bound::Included(&1), true), None);
-        assert_eq!(compute_positions_to_skip(&empty, std::ops::Bound::Excluded(&1), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&empty, std::ops::Bound::Included(&1), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&empty, std::ops::Bound::Excluded(&1), false),
+            None
+        );
     }
-
 }

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -14,6 +14,10 @@ pub trait NodeLike<T: Ord> {
     #[allow(dead_code)]
     fn len(&self) -> usize;
     #[allow(dead_code)]
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    #[allow(dead_code)]
     fn capacity(&self) -> usize;
     #[allow(dead_code)]
     fn insert(&mut self, value: T) -> (bool, usize);
@@ -46,7 +50,7 @@ pub trait NodeLike<T: Ord> {
 }
 
 #[inline]
-fn search<Q, T: Ord>(haystack: &[T], needle: &Q) -> Result<usize, usize>
+fn search<Q, T>(haystack: &[T], needle: &Q) -> Result<usize, usize>
 where
     T: Borrow<Q> + Ord,
     Q: Ord + ?Sized,
@@ -58,7 +62,7 @@ where
         let p = haystack.as_ptr().cast::<T>();
         let mut m = j >> 1;
         while i != j {
-            match (*p.add(m)).borrow().cmp(&needle) {
+            match (*p.add(m)).borrow().cmp(needle) {
                 Ordering::Equal => return Ok(m),
                 Ordering::Less => {
                     i = m + 1;
@@ -80,7 +84,7 @@ enum Direction<'a, T> {
 }
 
 #[inline]
-fn compute_positions_to_skip<Q, T: Ord>(haystack: &[T], bound: std::ops::Bound<&Q>, forward: bool) -> Option<usize>
+fn compute_positions_to_skip<Q, T>(haystack: &[T], bound: std::ops::Bound<&Q>, forward: bool) -> Option<usize>
 where
     T: Borrow<Q> + Ord,
     Q: Ord + ?Sized,
@@ -99,7 +103,7 @@ where
             match iter {
                 Direction::Forward(iter) => {
                     for item in iter {
-                        match item.borrow().cmp(&value) {
+                        match item.borrow().cmp(value) {
                             Ordering::Less => positions_to_skip += 1,
                             Ordering::Equal => match bound {
                                 std::ops::Bound::Included(_) => break,
@@ -115,7 +119,7 @@ where
                 }
                 Direction::Backward(iter) => {
                     for item in iter {
-                        match item.borrow().cmp(&value) {
+                        match item.borrow().cmp(value) {
                             Ordering::Greater => positions_to_skip += 1,
                             Ordering::Equal => match bound {
                                 std::ops::Bound::Included(_) => break,
@@ -167,7 +171,7 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     }
     #[inline]
     fn insert(&mut self, value: T) -> (bool, usize) {
-        match search(&self, &value) {
+        match search(self, &value) {
             Ok(idx) => (false, idx),
             Err(idx) => {
                 self.insert(idx, value);
@@ -181,10 +185,7 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
         T: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        match search(&self, &value) {
-            Ok(_) => true,
-            Err(_) => false,
-        }
+        search(self, value).is_ok()
     }
     #[inline]
     fn try_select<Q>(&self, value: &Q) -> Option<usize>
@@ -192,10 +193,7 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
         T: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        match search(&self, &value) {
-            Ok(index) => Some(index),
-            Err(_) => None,
-        }
+        search(self, value).ok()
     }
     #[inline]
     fn rank<Q>(&self, bound: std::ops::Bound<&Q>, from_start: bool) -> Option<usize>
@@ -203,7 +201,7 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
         T: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        compute_positions_to_skip(&self, bound, from_start)
+        compute_positions_to_skip(self, bound, from_start)
     }
     #[inline]
     fn delete<Q>(&mut self, value: &Q) -> Option<(T, usize)>
@@ -211,7 +209,7 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
         T: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        match search(&self, value) {
+        match search(self, value) {
             Ok(idx) => Some((self.remove(idx), idx)),
             Err(_) => None,
         }

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -40,7 +40,9 @@ pub trait NodeLike<T: Ord> {
     #[allow(dead_code)]
     fn min(&self) -> Option<&T>;
     #[allow(dead_code)]
-    fn iter<'a>(&'a self) -> std::slice::Iter<'a, T> where T: 'a;
+    fn iter<'a>(&'a self) -> std::slice::Iter<'a, T>
+    where
+        T: 'a;
 }
 
 #[inline]
@@ -78,14 +80,18 @@ enum Direction<'a, T> {
 }
 
 #[inline]
-fn compute_positions_to_skip<Q, T: Ord>(haystack: &[T], bound: std::ops::Bound<&Q>, forward: bool) -> Option<usize>
+fn compute_positions_to_skip<Q, T: Ord>(
+    haystack: &[T],
+    bound: std::ops::Bound<&Q>,
+    forward: bool,
+) -> Option<usize>
 where
     T: Borrow<Q> + Ord,
     Q: Ord + ?Sized,
 {
     match bound {
         // If the bound is unbounded, then no skipping is needed
-        std::ops::Bound::Unbounded => { None }
+        std::ops::Bound::Unbounded => None,
         std::ops::Bound::Included(value) | std::ops::Bound::Excluded(value) => {
             let mut positions_to_skip = -1;
             let iter = if forward {
@@ -99,9 +105,12 @@ where
                     for item in iter {
                         match item.borrow().cmp(&value) {
                             Ordering::Less => positions_to_skip += 1,
-                                Ordering::Equal => match bound {
+                            Ordering::Equal => match bound {
                                 std::ops::Bound::Included(_) => break,
-                                std::ops::Bound::Excluded(_) => { positions_to_skip += 1; break },
+                                std::ops::Bound::Excluded(_) => {
+                                    positions_to_skip += 1;
+                                    continue;
+                                }
                                 _ => unreachable!(),
                             },
                             Ordering::Greater => break,
@@ -114,7 +123,10 @@ where
                             Ordering::Greater => positions_to_skip += 1,
                             Ordering::Equal => match bound {
                                 std::ops::Bound::Included(_) => break,
-                                std::ops::Bound::Excluded(_) => { positions_to_skip += 1; break },
+                                std::ops::Bound::Excluded(_) => {
+                                    positions_to_skip += 1;
+                                    continue;
+                                }
                                 _ => unreachable!(),
                             },
                             Ordering::Less => break,
@@ -227,7 +239,8 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     }
     #[inline]
     fn iter<'a>(&'a self) -> std::slice::Iter<'a, T>
-    where T: 'a
+    where
+        T: 'a,
     {
         self.deref().iter()
     }
@@ -237,40 +250,149 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
 mod tests {
     use super::*;
 
+    #[derive(Eq, Ord, PartialEq, PartialOrd)]
+    struct KeyThenValue(usize, &'static str);
+
+    impl Borrow<usize> for KeyThenValue {
+        fn borrow(&self) -> &usize {
+            &self.0
+        }
+    }
+
     #[test]
     fn test_search_bound() {
         let vec = vec![1, 3, 5, 7, 9];
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, false), None);
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, false),
+            None
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), true), Some(1));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), true), Some(3));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), true), Some(4));
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), true),
+            Some(1)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), true),
+            Some(3)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), true),
+            Some(4)
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), true), Some(0));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), true), Some(2));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), true), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), true), Some(4));
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), true),
+            Some(0)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), true),
+            Some(2)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), true),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), true),
+            Some(4)
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), false), Some(3));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), false), Some(1));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), false), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), false),
+            Some(3)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), false),
+            Some(1)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), false),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), false),
+            None
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), false), Some(2));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), false), Some(0));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), false),
+            Some(2)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), false),
+            Some(0)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), false),
+            None
+        );
 
         let empty: Vec<i32> = vec![];
-        assert_eq!(compute_positions_to_skip(&empty, std::ops::Bound::Included(&1), true), None);
-        assert_eq!(compute_positions_to_skip(&empty, std::ops::Bound::Excluded(&1), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&empty, std::ops::Bound::Included(&1), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&empty, std::ops::Bound::Excluded(&1), false),
+            None
+        );
     }
 
+    #[test]
+    fn excluded_borrowed_bound_skips_all_equal_keys() {
+        let node = vec![
+            KeyThenValue(1, "a"),
+            KeyThenValue(1, "b"),
+            KeyThenValue(2, "a"),
+        ];
+
+        assert_eq!(
+            compute_positions_to_skip(&node, std::ops::Bound::Excluded(&1), true),
+            Some(1),
+        );
+    }
+
+    #[test]
+    fn excluded_borrowed_end_bound_skips_all_equal_keys() {
+        let node = vec![
+            KeyThenValue(1, "a"),
+            KeyThenValue(2, "a"),
+            KeyThenValue(2, "b"),
+            KeyThenValue(3, "a"),
+        ];
+
+        assert_eq!(
+            compute_positions_to_skip(&node, std::ops::Bound::Excluded(&2), false),
+            Some(2),
+        );
+    }
 }

--- a/src/core/pair.rs
+++ b/src/core/pair.rs
@@ -5,8 +5,7 @@ use std::borrow::Borrow;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, Clone, Hash)]
-pub struct Pair<K, V>
-{
+pub struct Pair<K, V> {
     pub key: K,
     pub value: V,
 }

--- a/src/core/pair.rs
+++ b/src/core/pair.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Borrow;
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, Hash)]
+#[derive(Debug, Default, Clone)]
 pub struct Pair<K, V> {
     pub key: K,
     pub value: V,
@@ -26,7 +26,7 @@ where
     K: Ord,
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.key.partial_cmp(&other.key)
+        Some(self.cmp(other))
     }
 }
 
@@ -36,6 +36,15 @@ where
 {
     fn cmp(&self, other: &Self) -> Ordering {
         self.key.cmp(&other.key)
+    }
+}
+
+impl<K, V> std::hash::Hash for Pair<K, V>
+where
+    K: std::hash::Hash,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ enum NodeEntry {
     },
     Empty {
         node_idx: usize,
-    }
+    },
 }
 
 impl<T: Ord> BTreeSet<T> {
@@ -116,9 +116,7 @@ impl<T: Ord> BTreeSet<T> {
     /// let mut set: BTreeSet<i32> = BTreeSet::new();
     /// ```
     pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
+        Self { ..Default::default() }
     }
     /// Makes a new, empty `BTreeSet` with the given maximum node size. Allocates one vec with
     /// the capacity set to be the specified node size.
@@ -203,8 +201,7 @@ impl<T: Ord> BTreeSet<T> {
         Q: Ord + ?Sized,
     {
         let node_idx = self.locate_node(value);
-        let position_within_node =
-            self.inner[node_idx].partition_point(|item| item.borrow() < value);
+        let position_within_node = self.inner[node_idx].partition_point(|item| item.borrow() < value);
 
         (node_idx, position_within_node)
     }
@@ -518,13 +515,16 @@ impl<T: Ord> BTreeSet<T> {
         R: FnMut(&Q) -> bool,
     {
         let (node_idx, position_within_node) = self.locate_value_cmp(cmp);
-        self.inner.get(node_idx)
-        .and_then(|candidate_node| candidate_node.get(position_within_node))
-        .filter(|&candidate_value| cmp2(candidate_value.borrow()))
-        .map(|_| NodeEntry::Exist { node_idx, position_within_node })
-        .unwrap_or(NodeEntry::Empty { node_idx })
+        self.inner
+            .get(node_idx)
+            .and_then(|candidate_node| candidate_node.get(position_within_node))
+            .filter(|&candidate_value| cmp2(candidate_value.borrow()))
+            .map(|_| NodeEntry::Exist {
+                node_idx,
+                position_within_node,
+            })
+            .unwrap_or(NodeEntry::Empty { node_idx })
     }
-
 
     fn delete_cmp<P, Q, R>(&mut self, cmp: P, cmp2: R) -> (Option<T>, bool)
     where
@@ -534,9 +534,10 @@ impl<T: Ord> BTreeSet<T> {
         R: FnMut(&Q) -> bool,
     {
         let removal = match self.find_cmp(cmp, cmp2) {
-            NodeEntry::Exist { node_idx, position_within_node } => {
-                Some(self.delete_at(node_idx, position_within_node))
-            }
+            NodeEntry::Exist {
+                node_idx,
+                position_within_node,
+            } => Some(self.delete_at(node_idx, position_within_node)),
             NodeEntry::Empty { .. } => None,
         };
 
@@ -1119,8 +1120,7 @@ impl<T: Ord> BTreeSet<T> {
         R: RangeBounds<usize>,
     {
         let mut global_front_idx: usize = 0;
-        let mut global_back_idx: usize =
-            self.index.prefix_sum(self.inner.len(), 0).saturating_sub(1);
+        let mut global_back_idx: usize = self.index.prefix_sum(self.inner.len(), 0).saturating_sub(1);
 
         // Solving global indexes
         let start = range.start_bound();
@@ -1244,10 +1244,8 @@ impl<T: Ord> BTreeSet<T> {
     where
         R: RangeBounds<usize>,
     {
-        let (
-            (global_front_idx, front_node_idx, front_start_idx),
-            (global_back_idx, back_node_idx, back_start_idx),
-        ) = self.resolve_range(range);
+        let ((global_front_idx, front_node_idx, front_start_idx), (global_back_idx, back_node_idx, back_start_idx)) =
+            self.resolve_range(range);
 
         let front_iter = if front_node_idx < self.inner.len() {
             Some(self.inner[front_node_idx][front_start_idx..].iter())
@@ -1374,8 +1372,7 @@ where
             if self.current_front_node_idx >= self.btree.inner.len() {
                 return None;
             }
-            self.current_front_iterator =
-                Some(self.btree.inner[self.current_front_node_idx].iter());
+            self.current_front_iterator = Some(self.btree.inner[self.current_front_node_idx].iter());
 
             self.next()
         }
@@ -1390,11 +1387,7 @@ where
         if self.current_front_idx == self.current_back_idx {
             return None;
         }
-        if let Some(value) = self
-            .current_back_iterator
-            .as_mut()
-            .and_then(|i| i.next_back())
-        {
+        if let Some(value) = self.current_back_iterator.as_mut().and_then(|i| i.next_back()) {
             self.current_back_idx -= 1;
             Some(value)
         } else {
@@ -1866,10 +1859,7 @@ where
         self.key
     }
     pub fn insert(self, value: V) -> &'a mut V {
-        let rank = self
-            .map
-            .set
-            .rank_cmp(|item: &Pair<K, V>| &item.key < &self.key);
+        let rank = self.map.set.rank_cmp(|item: &Pair<K, V>| &item.key < &self.key);
         self.map.insert(self.key, value);
 
         self.map.get_mut_index(rank).unwrap()
@@ -2172,9 +2162,7 @@ where
         K: Borrow<Q> + Ord,
         Q: Ord + ?Sized,
     {
-        let (node_idx, position_within_node) = self
-            .set
-            .locate_value_cmp(|item: &Pair<K, V>| item.key.borrow() < key);
+        let (node_idx, position_within_node) = self.set.locate_value_cmp(|item: &Pair<K, V>| item.key.borrow() < key);
         if let Some(candidate_node) = self.set.inner.get(node_idx) {
             if let Some(candidate_value) = candidate_node.get(position_within_node) {
                 if candidate_value.key.borrow() == key {
@@ -2209,12 +2197,8 @@ where
         K: Borrow<Q> + Ord,
         Q: Ord,
     {
-        let (node_idx, position_within_node) = self
-            .set
-            .locate_value_cmp(|item: &Pair<K, V>| item.key.borrow() < key);
-        if self.set.inner.get(node_idx).is_some()
-            && self.set.inner[node_idx].get(position_within_node).is_some()
-        {
+        let (node_idx, position_within_node) = self.set.locate_value_cmp(|item: &Pair<K, V>| item.key.borrow() < key);
+        if self.set.inner.get(node_idx).is_some() && self.set.inner[node_idx].get(position_within_node).is_some() {
             let entry = self.set.inner[node_idx].get_mut(position_within_node)?;
             if key == entry.key.borrow() {
                 return Some(&mut entry.value);
@@ -2277,16 +2261,17 @@ where
         let cmp2 = |item: &Pair<K, V>| item.key == key;
 
         match self.set.find_cmp(cmp, cmp2) {
-            NodeEntry::Exist { node_idx, position_within_node } => {
-                std::mem::swap(
-                    &mut self.set.inner[node_idx][position_within_node].value,
-                    &mut value);
+            NodeEntry::Exist {
+                node_idx,
+                position_within_node,
+            } => {
+                std::mem::swap(&mut self.set.inner[node_idx][position_within_node].value, &mut value);
                 Some(value)
-            },
+            }
             NodeEntry::Empty { node_idx } => {
                 self.set.insert_at(node_idx, Pair { key, value });
                 None
-            },
+            }
         }
     }
     /// Creates a consuming iterator visiting all the keys, in sorted order.
@@ -2370,9 +2355,7 @@ where
     /// assert_eq!((*first_key, *first_value), (1, "a"));
     /// ```
     pub fn iter(&self) -> IterMap<K, V> {
-        IterMap {
-            inner: self.set.iter(),
-        }
+        IterMap { inner: self.set.iter() }
     }
     /// Gets a mutable iterator over the entries of the map, sorted by key.
     ///
@@ -2415,7 +2398,7 @@ where
                 inner,
                 current_front_node_idx: 0,
                 current_front_idx: 0,
-                current_back_node_idx: 0,  // Same as front for single node
+                current_back_node_idx: 0, // Same as front for single node
                 current_back_idx: len.wrapping_sub(1),
                 current_front_iterator: front_iter,
                 current_back_iterator: back_iter,
@@ -2462,9 +2445,7 @@ where
     /// assert_eq!(keys, [1, 2]);
     /// ```
     pub fn keys(&self) -> Keys<K, V> {
-        Keys {
-            inner: self.set.iter(),
-        }
+        Keys { inner: self.set.iter() }
     }
     /// Returns the last key-value pair in the map.
     /// The key in this pair is the maximum key in the map.
@@ -2523,9 +2504,7 @@ where
     /// map.insert(1, "a");
     /// ```
     pub fn new() -> Self {
-        Self {
-            ..Default::default()
-        }
+        Self { ..Default::default() }
     }
     /// Makes a new, empty `BTreeSet` with the given maximum node size. Allocates one vec with
     /// the capacity set to be the specified node size.
@@ -2670,22 +2649,14 @@ where
         R: RangeBounds<Q>,
     {
         let start_idx = match range.start_bound() {
-            Bound::Included(bound) => self
-                .set
-                .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound),
-            Bound::Excluded(bound) => self
-                .set
-                .rank_cmp(|item: &Pair<K, V>| item.key.borrow() <= bound),
+            Bound::Included(bound) => self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound),
+            Bound::Excluded(bound) => self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() <= bound),
             Bound::Unbounded => 0,
         };
         let end_idx = match range.end_bound() {
-            Bound::Included(bound) => self
-                .set
-                .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound),
+            Bound::Included(bound) => self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound),
             Bound::Excluded(bound) => {
-                let rank = self
-                    .set
-                    .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound);
+                let rank = self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < bound);
                 if rank == 0 {
                     // No elements before this bound, return empty range
                     return (1, 0);
@@ -2745,10 +2716,8 @@ where
     where
         R: RangeBounds<usize>,
     {
-        let (
-            (global_front_idx, front_node_idx, front_start_idx),
-            (global_back_idx, back_node_idx, back_start_idx),
-        ) = self.set.resolve_range(range);
+        let ((global_front_idx, front_node_idx, front_start_idx), (global_back_idx, back_node_idx, back_start_idx)) =
+            self.set.resolve_range(range);
         let end = self.set.inner[back_node_idx].len();
 
         let mut inner = self.set.inner.iter_mut();
@@ -2937,9 +2906,7 @@ where
         Q: Ord,
     {
         BTreeMap {
-            set: self
-                .set
-                .split_off_cmp(|item: &Pair<K, V>| item.key.borrow() < key),
+            set: self.set.split_off_cmp(|item: &Pair<K, V>| item.key.borrow() < key),
         }
     }
     /// Gets an iterator over the values of the map, in order by key.
@@ -2959,9 +2926,7 @@ where
     /// assert_eq!(values, ["hello", "goodbye"]);
     /// ```
     pub fn values(&self) -> Values<K, V> {
-        Values {
-            inner: self.set.iter(),
-        }
+        Values { inner: self.set.iter() }
     }
     /// Gets a mutable iterator over the values of the map, in order by key.
     ///
@@ -2985,9 +2950,7 @@ where
     ///                     String::from("goodbye!")]);
     /// ```
     pub fn values_mut(&mut self) -> ValuesMut<K, V> {
-        ValuesMut {
-            inner: self.iter_mut(),
-        }
+        ValuesMut { inner: self.iter_mut() }
     }
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
     ///
@@ -3113,14 +3076,8 @@ where
         Q: Ord,
     {
         let start_idx = match bound {
-            Bound::Included(start) => self
-                .set
-                .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < start),
-            Bound::Excluded(start) => {
-                self.set
-                    .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < start)
-                    + 1
-            }
+            Bound::Included(start) => self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < start),
+            Bound::Excluded(start) => self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < start) + 1,
             Bound::Unbounded => 0,
         };
 
@@ -3154,8 +3111,7 @@ where
         Q: Ord + ?Sized,
         K: Borrow<Q>,
     {
-        self.set
-            .rank_cmp(|item: &Pair<K, V>| item.key.borrow() < value)
+        self.set.rank_cmp(|item: &Pair<K, V>| item.key.borrow() < value)
     }
 }
 
@@ -3197,9 +3153,7 @@ where
     type IntoIter = IterMap<'a, K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
-        IterMap {
-            inner: self.set.iter(),
-        }
+        IterMap { inner: self.set.iter() }
     }
 }
 
@@ -3581,8 +3535,9 @@ where
                 return None;
             }
             // Handle single node case or adjacent nodes
-            if self.current_front_node_idx == self.current_back_node_idx ||
-               self.current_front_node_idx == self.current_back_node_idx - 1 {
+            if self.current_front_node_idx == self.current_back_node_idx
+                || self.current_front_node_idx == self.current_back_node_idx - 1
+            {
                 // take from the current front iter
                 if let Some(entry) = self.current_front_iterator.next_back() {
                     if self.current_back_idx > 0 {
@@ -3822,13 +3777,12 @@ mod tests {
 
         let expected_output: Vec<isize> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-        let actual_node =
-            input
-                .iter()
-                .fold(Node::with_capacity(DEFAULT_INNER_SIZE), |mut acc, curr| {
-                    NodeLike::insert(&mut acc, *curr);
-                    acc
-                });
+        let actual_node = input
+            .iter()
+            .fold(Node::with_capacity(DEFAULT_INNER_SIZE), |mut acc, curr| {
+                NodeLike::insert(&mut acc, *curr);
+                acc
+            });
 
         let actual_output: Vec<isize> = actual_node.iter().cloned().collect();
 
@@ -3950,10 +3904,7 @@ mod tests {
         btree.iter().for_each(|item| {
             if *item < DEFAULT_INNER_SIZE {
                 assert_eq!(front_spine.get_index(0), front_spine.first());
-                assert_eq!(
-                    front_spine.pop_first().unwrap() + 1,
-                    *front_spine.first().unwrap()
-                );
+                assert_eq!(front_spine.pop_first().unwrap() + 1, *front_spine.first().unwrap());
             } else {
                 assert_eq!(front_spine.pop_first().unwrap(), DEFAULT_INNER_SIZE);
                 assert_eq!(front_spine.first(), None);
@@ -3962,14 +3913,8 @@ mod tests {
 
         input.iter().rev().for_each(|item| {
             if *item > 0 {
-                assert_eq!(
-                    back_spine.get_index(back_spine.len() - 1),
-                    back_spine.last()
-                );
-                assert_eq!(
-                    back_spine.pop_last().unwrap() - 1,
-                    *back_spine.last().unwrap()
-                );
+                assert_eq!(back_spine.get_index(back_spine.len() - 1), back_spine.last());
+                assert_eq!(back_spine.pop_last().unwrap() - 1, *back_spine.last().unwrap());
             } else {
                 assert_eq!(back_spine.pop_last(), Some(0));
                 assert_eq!(back_spine.last(), None);
@@ -4000,10 +3945,7 @@ mod tests {
 
         expected_output.into_iter().for_each(|item| {
             assert_eq!(*btree.get_index(item).unwrap(), item);
-            assert_eq!(
-                *btree.get_index(item).unwrap(),
-                *btree.lower_bound(&item).unwrap()
-            );
+            assert_eq!(*btree.get_index(item).unwrap(), *btree.lower_bound(&item).unwrap());
             assert!(btree.contains(&item));
         });
     }
@@ -4025,14 +3967,10 @@ mod tests {
         let btree = BTreeMap::from_iter((0..(DEFAULT_INNER_SIZE * 10)).enumerate().rev());
         assert_eq!(btree.set.inner.len(), 19);
         let expected_forward = Vec::from_iter((0..(DEFAULT_INNER_SIZE * 10)).enumerate());
-        btree
-            .clone()
-            .iter_mut()
-            .zip(expected_forward)
-            .for_each(|(lhs, rhs)| {
-                assert_eq!(*lhs.0, rhs.0);
-                assert_eq!(*lhs.1, rhs.1);
-            });
+        btree.clone().iter_mut().zip(expected_forward).for_each(|(lhs, rhs)| {
+            assert_eq!(*lhs.0, rhs.0);
+            assert_eq!(*lhs.1, rhs.1);
+        });
 
         let expected_backward = Vec::from_iter((0..(DEFAULT_INNER_SIZE * 10)).enumerate().rev());
         btree
@@ -4083,26 +4021,11 @@ mod tests {
             Vec::from_iter(btree.range_idx(..10).cloned()),
             Vec::from_iter(btree.iter().cloned())
         );
-        assert_eq!(
-            Vec::from_iter(btree.range_idx(1..2).cloned()),
-            first_to_second
-        );
-        assert_eq!(
-            Vec::from_iter(btree.range_idx(3..10).cloned()),
-            three_til_end
-        );
-        assert_eq!(
-            Vec::from_iter(btree.range_idx(0..4).cloned()),
-            start_til_four
-        );
-        assert_eq!(
-            Vec::from_iter(btree.range_idx(0..10).cloned()),
-            start_til_end
-        );
-        assert_eq!(
-            Vec::from_iter(btree.range_idx(5..=6).cloned()),
-            five_til_six_included
-        );
+        assert_eq!(Vec::from_iter(btree.range_idx(1..2).cloned()), first_to_second);
+        assert_eq!(Vec::from_iter(btree.range_idx(3..10).cloned()), three_til_end);
+        assert_eq!(Vec::from_iter(btree.range_idx(0..4).cloned()), start_til_four);
+        assert_eq!(Vec::from_iter(btree.range_idx(0..10).cloned()), start_til_end);
+        assert_eq!(Vec::from_iter(btree.range_idx(5..=6).cloned()), five_til_six_included);
         assert_eq!(
             Vec::from_iter(btree.range_idx(0..=7).cloned()),
             start_til_seven_included
@@ -4195,9 +4118,7 @@ mod tests {
     #[test]
     fn test_non_boolean_set_operations() {
         let left_spine = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 1)).into_iter());
-        let right_spine = BTreeSet::from_iter(
-            ((DEFAULT_INNER_SIZE - 1)..((DEFAULT_INNER_SIZE + 1) * 2)).into_iter(),
-        );
+        let right_spine = BTreeSet::from_iter(((DEFAULT_INNER_SIZE - 1)..((DEFAULT_INNER_SIZE + 1) * 2)).into_iter());
 
         let mut union = left_spine.clone();
         let mut temp_right_spine = right_spine.clone();
@@ -4215,14 +4136,8 @@ mod tests {
         let left_diff = Vec::from_iter(0..(DEFAULT_INNER_SIZE - 1));
         let right_diff = Vec::from_iter((DEFAULT_INNER_SIZE + 1)..((DEFAULT_INNER_SIZE + 1) * 2));
 
-        assert_eq!(
-            left_diff,
-            Vec::from_iter(left_spine.difference(&right_spine).cloned())
-        );
-        assert_eq!(
-            right_diff,
-            Vec::from_iter(right_spine.difference(&left_spine).cloned())
-        );
+        assert_eq!(left_diff, Vec::from_iter(left_spine.difference(&right_spine).cloned()));
+        assert_eq!(right_diff, Vec::from_iter(right_spine.difference(&left_spine).cloned()));
 
         let intersection = vec![DEFAULT_INNER_SIZE - 1, DEFAULT_INNER_SIZE];
         assert_eq!(
@@ -4248,8 +4163,7 @@ mod tests {
         assert!(empty_set.is_empty());
         let a = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 1)).into_iter());
         let b = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 2)).into_iter());
-        let c =
-            BTreeSet::from_iter(((DEFAULT_INNER_SIZE + 2)..(DEFAULT_INNER_SIZE + 4)).into_iter());
+        let c = BTreeSet::from_iter(((DEFAULT_INNER_SIZE + 2)..(DEFAULT_INNER_SIZE + 4)).into_iter());
 
         assert!(a.is_subset(&a));
         assert!(a.is_superset(&a));
@@ -4290,12 +4204,7 @@ mod tests {
         let btree: BTreeSet<usize> = BTreeSet::from_iter(0..10);
         assert_eq!(btree.range((Included(5), Included(10))).count(), 5);
         assert_eq!(btree.range((Included(5), Included(11))).count(), 5);
-        assert_eq!(
-            btree
-                .range((Included(5), Included(10 + DEFAULT_INNER_SIZE)))
-                .count(),
-            5
-        );
+        assert_eq!(btree.range((Included(5), Included(10 + DEFAULT_INNER_SIZE))).count(), 5);
         assert_eq!(btree.range((Included(0), Included(11))).count(), 10);
     }
 
@@ -4316,10 +4225,7 @@ mod tests {
             (0..=DEFAULT_INNER_SIZE + 1).count()
         );
 
-        assert_eq!(
-            btree.iter().rev().count(),
-            (0..(DEFAULT_INNER_SIZE + 10)).count()
-        );
+        assert_eq!(btree.iter().rev().count(), (0..(DEFAULT_INNER_SIZE + 10)).count());
         assert_eq!(
             btree.range(0..DEFAULT_INNER_SIZE).rev().count(),
             (0..DEFAULT_INNER_SIZE).count()
@@ -4351,12 +4257,7 @@ mod tests {
         assert_eq!(btree.range(..1).rev().count(), 0);
 
         assert_eq!(btree.range(..DEFAULT_INNER_SIZE).count(), 0);
-        assert_eq!(
-            btree
-                .range(DEFAULT_INNER_SIZE..DEFAULT_INNER_SIZE * 2)
-                .count(),
-            0
-        );
+        assert_eq!(btree.range(DEFAULT_INNER_SIZE..DEFAULT_INNER_SIZE * 2).count(), 0);
     }
 
     #[test]
@@ -4418,7 +4319,7 @@ mod tests {
         let expected_backward = vec![(3, 30), (2, 20), (1, 10)];
         for (i, (k, v)) in map.iter_mut().rev().enumerate() {
             assert_eq!(*k, expected_backward[i].0);
-            assert_eq!(*v, expected_backward[i].1); 
+            assert_eq!(*v, expected_backward[i].1);
         }
     }
 
@@ -4426,19 +4327,19 @@ mod tests {
     fn test_indexset_btreemap_overflow_bug() {
         // This test reproduces the "attempt to subtract with overflow" panic
         // that occurs in indexset::BTreeMap::range_to_idx at line 2639
-        
+
         let mut map = BTreeMap::new();
-        
+
         // Insert the same keys as in the failing test
         map.insert(vec![1, 2, 3, 4], 1);
         map.insert(vec![1, 2, 3, 7], 2);
         map.insert(vec![1, 2, 4, 5], 3);
         let end_key = vec![1, 2, 3, 4];
-        
+
         let mut range_iter = map.range(..end_key).rev();
-        
+
         let result = range_iter.next();
-        
+
         // In a working implementation, this should return None
         // since there are no keys before [1,2,3,4]
         assert!(result.is_none(), "Expected None when ranging before first key");
@@ -4471,10 +4372,16 @@ mod tests {
         // RangeFromExcluding with non-existing key [1,2,3,6]
         // Should return [1,2,3,7] but returns [1,2,4,5]
         let non_existing_key = vec![1, 2, 3, 6];
-        let range = RangeFromExcluding { from: &non_existing_key };
+        let range = RangeFromExcluding {
+            from: &non_existing_key,
+        };
         let result = map.range(range).next().unwrap();
-        
-        assert_eq!(result.0, &vec![1, 2, 3, 7], "RangeFromExcluding skips entries incorrectly");
+
+        assert_eq!(
+            result.0,
+            &vec![1, 2, 3, 7],
+            "RangeFromExcluding skips entries incorrectly"
+        );
         assert_eq!(*result.1, 2);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,11 +129,11 @@ impl<T: Ord> BTreeSet<T> {
     ///
     /// let mut set: BTreeSet<i32> = BTreeSet::with_maximum_node_size(128);
     pub fn with_maximum_node_size(maximum_node_size: usize) -> Self {
-        let mut new: Self = Default::default();
-        new.inner = vec![Node::with_capacity(maximum_node_size)];
-        new.node_capacity = maximum_node_size;
-
-        new
+        Self {
+            inner: vec![Node::with_capacity(maximum_node_size)],
+            node_capacity: maximum_node_size,
+            ..Default::default()
+        }
     }
     /// Clears the set, removing all elements.
     ///
@@ -260,7 +260,7 @@ impl<T: Ord> BTreeSet<T> {
     }
     fn get_mut_index(&mut self, index: usize) -> Option<&mut T> {
         let (node_idx, position_within_node) = self.locate_ith(index);
-        if let Some(_) = self.inner.get(node_idx) {
+        if self.inner.get(node_idx).is_some() {
             return self.inner[node_idx].get_mut(position_within_node);
         }
 
@@ -467,7 +467,7 @@ impl<T: Ord> BTreeSet<T> {
 
         let mut decrease_length = false;
         // check whether the node has to be deleted
-        if self.inner[node_idx].len() == 0 {
+        if self.inner[node_idx].is_empty() {
             // delete it as long as it is not the last remaining node
             if self.inner.len() > 1 {
                 self.inner.remove(node_idx);
@@ -611,8 +611,8 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.first(), Some(&1));
     /// ```
     pub fn first(&self) -> Option<&T> {
-        if let Some(candidate_node) = self.inner.get(0) {
-            return candidate_node.get(0);
+        if let Some(candidate_node) = self.inner.first() {
+            return candidate_node.first();
         }
 
         None
@@ -635,9 +635,9 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set.last(), Some(&2));
     /// ```
     pub fn last(&self) -> Option<&T> {
-        if let Some(candidate_node) = self.inner.get(self.inner.len() - 1) {
-            if candidate_node.len() > 0 {
-                return candidate_node.get(candidate_node.len() - 1);
+        if let Some(candidate_node) = self.inner.last() {
+            if !candidate_node.is_empty() {
+                return candidate_node.last();
             }
         }
 
@@ -836,7 +836,7 @@ impl<T: Ord> BTreeSet<T> {
     /// assert_eq!(set_iter.next(), Some(&3));
     /// assert_eq!(set_iter.next(), None);
     /// ```
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter::new(self)
     }
     /// Visits the elements representing the union,
@@ -1017,7 +1017,7 @@ impl<T: Ord> BTreeSet<T> {
         latter_half.inner = remaining_nodes;
         latter_half.index = FenwickTree::from_iter(latter_half.inner.iter().map(|node| node.len()));
 
-        if self.inner[node_idx].len() == 0 && self.inner.len() > 1 {
+        if self.inner[node_idx].is_empty() && self.inner.len() > 1 {
             self.inner.remove(node_idx);
         }
 
@@ -1073,7 +1073,7 @@ impl<T: Ord> BTreeSet<T> {
         latter_half.inner = remaining_nodes;
         latter_half.index = FenwickTree::from_iter(latter_half.inner.iter().map(|node| node.len()));
 
-        if self.inner[node_idx].len() == 0 && self.inner.len() > 1 {
+        if self.inner[node_idx].is_empty() && self.inner.len() > 1 {
             self.inner.remove(node_idx);
         }
 
@@ -1501,7 +1501,7 @@ where
                 } else {
                     self.current_left = self.left_iter.next();
                 }
-            } else if let Some(_) = self.current_right {
+            } else if self.current_right.is_some() {
                 self.current_right = self.right_iter.next();
             } else {
                 return None;
@@ -1859,7 +1859,7 @@ where
         self.key
     }
     pub fn insert(self, value: V) -> &'a mut V {
-        let rank = self.map.set.rank_cmp(|item: &Pair<K, V>| &item.key < &self.key);
+        let rank = self.map.set.rank_cmp(|item: &Pair<K, V>| item.key < self.key);
         self.map.insert(self.key, value);
 
         self.map.get_mut_index(rank).unwrap()
@@ -2354,7 +2354,7 @@ where
     /// let (first_key, first_value) = map.iter().next().unwrap();
     /// assert_eq!((*first_key, *first_value), (1, "a"));
     /// ```
-    pub fn iter(&self) -> IterMap<K, V> {
+    pub fn iter(&self) -> IterMap<'_, K, V> {
         IterMap { inner: self.set.iter() }
     }
     /// Gets a mutable iterator over the entries of the map, sorted by key.
@@ -2379,7 +2379,7 @@ where
     ///     }
     /// }
     /// ```
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         let last_node_idx = self.set.inner.len() - 1;
         let len = self.set.len();
 
@@ -2444,7 +2444,7 @@ where
     /// let keys: Vec<_> = a.keys().cloned().collect();
     /// assert_eq!(keys, [1, 2]);
     /// ```
-    pub fn keys(&self) -> Keys<K, V> {
+    pub fn keys(&self) -> Keys<'_, K, V> {
         Keys { inner: self.set.iter() }
     }
     /// Returns the last key-value pair in the map.
@@ -2622,7 +2622,7 @@ where
     /// }
     /// assert_eq!(Some((&5, &"b")), map.range(4..).next());
     /// ```
-    pub fn range<Q, R>(&self, range: R) -> RangeMap<K, V>
+    pub fn range<Q, R>(&self, range: R) -> RangeMap<'_, K, V>
     where
         Q: Ord + ?Sized,
         K: Borrow<Q>,
@@ -2634,7 +2634,7 @@ where
             inner: self.set.range_idx(start_idx..=end_idx),
         }
     }
-    pub fn range_idx<R>(&self, range: R) -> RangeMap<K, V>
+    pub fn range_idx<R>(&self, range: R) -> RangeMap<'_, K, V>
     where
         R: RangeBounds<usize>,
     {
@@ -2664,7 +2664,7 @@ where
                 rank - 1
             }
             Bound::Unbounded => {
-                if self.len() == 0 {
+                if self.is_empty() {
                     // Empty map, return empty range
                     return (1, 0);
                 }
@@ -2702,7 +2702,7 @@ where
     ///     println!("{name} => {balance}");
     /// }
     /// ```
-    pub fn range_mut<Q, R>(&mut self, range: R) -> RangeMut<K, V>
+    pub fn range_mut<Q, R>(&mut self, range: R) -> RangeMut<'_, K, V>
     where
         Q: Ord + ?Sized,
         K: Borrow<Q>,
@@ -2712,7 +2712,7 @@ where
 
         self.range_mut_idx(start_idx..=end_idx)
     }
-    pub fn range_mut_idx<R>(&mut self, range: R) -> RangeMut<K, V>
+    pub fn range_mut_idx<R>(&mut self, range: R) -> RangeMut<'_, K, V>
     where
         R: RangeBounds<usize>,
     {
@@ -2925,7 +2925,7 @@ where
     /// let values: Vec<&str> = a.values().cloned().collect();
     /// assert_eq!(values, ["hello", "goodbye"]);
     /// ```
-    pub fn values(&self) -> Values<K, V> {
+    pub fn values(&self) -> Values<'_, K, V> {
         Values { inner: self.set.iter() }
     }
     /// Gets a mutable iterator over the values of the map, in order by key.
@@ -2949,7 +2949,7 @@ where
     /// assert_eq!(values, [String::from("hello!"),
     ///                     String::from("goodbye!")]);
     /// ```
-    pub fn values_mut(&mut self) -> ValuesMut<K, V> {
+    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
         ValuesMut { inner: self.iter_mut() }
     }
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
@@ -3784,7 +3784,7 @@ mod tests {
                 acc
             });
 
-        let actual_output: Vec<isize> = actual_node.iter().cloned().collect();
+        let actual_output = actual_node.to_vec();
 
         assert_eq!(expected_output, actual_output);
         assert_eq!(*actual_node.last().unwrap(), 10);
@@ -3794,20 +3794,20 @@ mod tests {
     fn test_halve() {
         let mut input: Vec<isize> = vec![];
         for item in 0..DEFAULT_INNER_SIZE {
-            input.push(item.clone() as isize);
+            input.push(item as isize);
         }
 
         let mut former_node = Node::with_capacity(DEFAULT_INNER_SIZE);
         input.iter().for_each(|item| {
-            NodeLike::insert(&mut former_node, item.clone());
+            NodeLike::insert(&mut former_node, *item);
         });
         let latter_node = former_node.halve();
 
         let expected_former_output: Vec<isize> = input[0..DEFAULT_CUTOFF].to_vec();
         let expected_latter_output: Vec<isize> = input[DEFAULT_CUTOFF..].to_vec();
 
-        let actual_former_output: Vec<isize> = former_node.iter().cloned().collect();
-        let actual_latter_output: Vec<isize> = latter_node.iter().cloned().collect();
+        let actual_former_output = former_node.to_vec();
+        let actual_latter_output = latter_node.to_vec();
 
         assert_eq!(expected_former_output, actual_former_output);
         assert_eq!(expected_latter_output, actual_latter_output);
@@ -3857,7 +3857,7 @@ mod tests {
         let input: Vec<usize> = (0..(DEFAULT_INNER_SIZE + 1)).into_iter().collect();
 
         let mut btree: BTreeSet<usize> = input.iter().fold(BTreeSet::new(), |mut acc, curr| {
-            acc.insert(curr.clone());
+            acc.insert(*curr);
             acc
         });
 
@@ -3876,7 +3876,7 @@ mod tests {
         let input: Vec<usize> = (0..(DEFAULT_INNER_SIZE + 1)).into_iter().collect();
 
         let mut btree: BTreeSet<usize> = input.iter().fold(BTreeSet::new(), |mut acc, curr| {
-            acc.insert(curr.clone());
+            acc.insert(*curr);
             acc
         });
 
@@ -3895,7 +3895,7 @@ mod tests {
         let input: Vec<usize> = (0..(DEFAULT_INNER_SIZE + 1)).into_iter().collect();
 
         let btree: BTreeSet<usize> = input.iter().fold(BTreeSet::new(), |mut acc, curr| {
-            acc.insert(curr.clone());
+            acc.insert(*curr);
             acc
         });
 
@@ -3939,7 +3939,7 @@ mod tests {
         let expected_output: Vec<usize> = (0..(DEFAULT_INNER_SIZE + 1)).collect();
 
         let btree: BTreeSet<usize> = input.iter().fold(BTreeSet::new(), |mut acc, curr| {
-            acc.insert(curr.clone());
+            acc.insert(*curr);
             acc
         });
 
@@ -3989,7 +3989,7 @@ mod tests {
         let btree = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE * 10)).rev());
         assert_eq!(btree.inner.len(), 19);
         let expected_forward = Vec::from_iter(0..(DEFAULT_INNER_SIZE * 10));
-        let actual_forward = Vec::from_iter(btree.clone().into_iter());
+        let actual_forward = Vec::from_iter(btree.clone());
         assert_eq!(expected_forward, actual_forward);
         let expected_backward = Vec::from_iter((0..(DEFAULT_INNER_SIZE * 10)).rev());
         let actual_backward = Vec::from_iter(btree.into_iter().rev());
@@ -4117,8 +4117,8 @@ mod tests {
 
     #[test]
     fn test_non_boolean_set_operations() {
-        let left_spine = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 1)).into_iter());
-        let right_spine = BTreeSet::from_iter(((DEFAULT_INNER_SIZE - 1)..((DEFAULT_INNER_SIZE + 1) * 2)).into_iter());
+        let left_spine = BTreeSet::from_iter(0..(DEFAULT_INNER_SIZE + 1));
+        let right_spine = BTreeSet::from_iter((DEFAULT_INNER_SIZE - 1)..((DEFAULT_INNER_SIZE + 1) * 2));
 
         let mut union = left_spine.clone();
         let mut temp_right_spine = right_spine.clone();
@@ -4161,9 +4161,9 @@ mod tests {
     fn test_boolean_set_operations() {
         let empty_set: BTreeSet<usize> = BTreeSet::new();
         assert!(empty_set.is_empty());
-        let a = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 1)).into_iter());
-        let b = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 2)).into_iter());
-        let c = BTreeSet::from_iter(((DEFAULT_INNER_SIZE + 2)..(DEFAULT_INNER_SIZE + 4)).into_iter());
+        let a = BTreeSet::from_iter(0..(DEFAULT_INNER_SIZE + 1));
+        let b = BTreeSet::from_iter(0..(DEFAULT_INNER_SIZE + 2));
+        let c = BTreeSet::from_iter((DEFAULT_INNER_SIZE + 2)..(DEFAULT_INNER_SIZE + 4));
 
         assert!(a.is_subset(&a));
         assert!(a.is_superset(&a));
@@ -4179,7 +4179,7 @@ mod tests {
     #[test]
     fn test_split_off() {
         let btree: BTreeSet<usize> = BTreeSet::from_iter(0..(DEFAULT_INNER_SIZE * 10));
-        for split in vec![
+        for split in [
             1,
             (DEFAULT_INNER_SIZE * 3) - 6,
             DEFAULT_INNER_SIZE,
@@ -4210,7 +4210,7 @@ mod tests {
 
     #[test]
     fn test_iterating_over_blocks() {
-        let btree = BTreeSet::from_iter((0..(DEFAULT_INNER_SIZE + 10)).into_iter());
+        let btree = BTreeSet::from_iter(0..(DEFAULT_INNER_SIZE + 10));
         assert_eq!(btree.iter().count(), (0..(DEFAULT_INNER_SIZE + 10)).count());
         assert_eq!(
             btree.range(0..DEFAULT_INNER_SIZE).count(),
@@ -4310,13 +4310,13 @@ mod tests {
         map.insert(2, 20);
         map.insert(3, 30);
 
-        let expected_forward = vec![(1, 10), (2, 20), (3, 30)];
+        let expected_forward = [(1, 10), (2, 20), (3, 30)];
         for (i, (k, v)) in map.iter_mut().enumerate() {
             assert_eq!(*k, expected_forward[i].0);
             assert_eq!(*v, expected_forward[i].1);
         }
 
-        let expected_backward = vec![(3, 30), (2, 20), (1, 10)];
+        let expected_backward = [(3, 30), (2, 20), (1, 10)];
         for (i, (k, v)) in map.iter_mut().rev().enumerate() {
             assert_eq!(*k, expected_backward[i].0);
             assert_eq!(*v, expected_backward[i].1);


### PR DESCRIPTION
- add `OrdMultiPair` implementation which sorts by `V: Ord`
- rework existing `MultiPair` as `RandomMultiPair`
- add benches to compare two implementations