### PR TITLE
Add support for `MultiPair` customization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ harness = false
 [[bench]]
 name = "concurrent"
 harness = false
+required-features = ["multimap"]

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -1,7 +1,10 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use crossbeam_skiplist::SkipSet;
-use rand::{thread_rng, Rng};
+use indexset::concurrent::multimap::BTreeMultiMap;
+use indexset::core::multipair::OrdMultiPair;
+use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
 use scc::TreeIndex;
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::thread;
 
@@ -16,6 +19,8 @@ const NUM_WRITERS: usize = 10;
 const NUM_THREADS: usize = NUM_READERS + NUM_WRITERS;
 const OPERATIONS_PER_THREAD: usize = 100_000;
 const TOTAL_OPERATIONS: usize = NUM_THREADS * OPERATIONS_PER_THREAD;
+const MULTIMAP_REMOVE_ENTRIES: usize = 20_000;
+const MULTIMAP_REMOVE_SEED: u64 = 42;
 
 // fn generate_operations(write_ratio: f64) -> Vec<Vec<Op>> {
 //     let mut rng = thread_rng();
@@ -177,5 +182,94 @@ fn bench_concurrent_btreeset(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_concurrent_btreeset);
+fn removal_entries(values_per_key: RangeInclusive<usize>) -> Vec<(usize, usize)> {
+    let mut rng = StdRng::seed_from_u64(MULTIMAP_REMOVE_SEED);
+    let mut entries = Vec::with_capacity(MULTIMAP_REMOVE_ENTRIES);
+    let mut key = 0;
+
+    while entries.len() < MULTIMAP_REMOVE_ENTRIES {
+        let value_count = rng.random_range(values_per_key.clone());
+        entries.extend((0..value_count).map(|value| (key, value)));
+        key += 1;
+    }
+
+    entries
+}
+
+fn build_random_multimap(entries: &[(usize, usize)]) -> BTreeMultiMap<usize, usize> {
+    let map = BTreeMultiMap::<usize, usize>::new();
+    for (key, value) in entries {
+        map.insert(*key, *value);
+    }
+
+    map
+}
+
+fn build_ord_multimap(
+    entries: &[(usize, usize)],
+) -> BTreeMultiMap<
+    usize,
+    usize,
+    Vec<OrdMultiPair<usize, usize>>,
+    OrdMultiPair<usize, usize>,
+> {
+    let map = BTreeMultiMap::<
+        usize,
+        usize,
+        Vec<OrdMultiPair<usize, usize>>,
+        OrdMultiPair<usize, usize>,
+    >::new();
+    for (key, value) in entries {
+        map.insert(*key, *value);
+    }
+
+    map
+}
+
+fn bench_multimap_removal(c: &mut Criterion) {
+    let usual_entries = removal_entries(1..=3);
+    let many_entries = removal_entries(1_000..=2_000);
+    let usual_target = *usual_entries.last().unwrap();
+    let many_target = *many_entries.last().unwrap();
+
+    let mut group = c.benchmark_group("BTreeMultiMap remove pair");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+    group.measurement_time(std::time::Duration::from_millis(500));
+
+    group.bench_function(BenchmarkId::new("random", "1-3 values per key"), |b| {
+        b.iter_batched_ref(
+            || build_random_multimap(&usual_entries),
+            |map| black_box(map.remove(&usual_target.0, &usual_target.1)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function(BenchmarkId::new("ord", "1-3 values per key"), |b| {
+        b.iter_batched_ref(
+            || build_ord_multimap(&usual_entries),
+            |map| black_box(map.remove(&usual_target.0, &usual_target.1)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function(BenchmarkId::new("random", "1000-2000 values per key"), |b| {
+        b.iter_batched_ref(
+            || build_random_multimap(&many_entries),
+            |map| black_box(map.remove(&many_target.0, &many_target.1)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function(BenchmarkId::new("ord", "1000-2000 values per key"), |b| {
+        b.iter_batched_ref(
+            || build_ord_multimap(&many_entries),
+            |map| black_box(map.remove(&many_target.0, &many_target.1)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_concurrent_btreeset, bench_multimap_removal);
 criterion_main!(benches);

--- a/src/cdc/change.rs
+++ b/src/cdc/change.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "multimap")]
 use {
-    crate::core::multipair::MultiPair,
+    crate::core::multipair::{OrdMultiPair, RandomMultiPair},
     crate::core::pair::Pair,
 };
 
@@ -149,48 +149,63 @@ impl<T> ChangeEventUnassigned<T> {
 
 
 #[cfg(feature = "multimap")]
-impl<K: Ord, V: PartialEq> From<ChangeEvent<MultiPair<K, V>>> for ChangeEvent<Pair<K, V>> {
-    fn from(ev: ChangeEvent<MultiPair<K, V>>) -> Self {
-        match ev {
-            ChangeEvent::InsertAt {
-                event_id,
-                max_value,
-                value,
-                index,
-            } => ChangeEvent::InsertAt {
-                event_id,
-                max_value: max_value.into(),
-                value: value.into(),
-                index,
-            },
-            ChangeEvent::RemoveAt {
-                event_id,
-                max_value,
-                value,
-                index,
-            } => ChangeEvent::RemoveAt {
-                event_id,
-                max_value: max_value.into(),
-                value: value.into(),
-                index,
-            },
-            ChangeEvent::CreateNode { event_id, max_value } => ChangeEvent::CreateNode {
-                event_id,
-                max_value: max_value.into(),
-            },
-            ChangeEvent::RemoveNode { event_id, max_value } => ChangeEvent::RemoveNode {
-                event_id,
-                max_value: max_value.into(),
-            },
-            ChangeEvent::SplitNode {
-                event_id,
-                max_value,
-                split_index,
-            } => ChangeEvent::SplitNode {
-                event_id,
-                max_value: max_value.into(),
-                split_index,
-            },
-        }
+fn multipair_change_event_into_pair<K, V, M>(ev: ChangeEvent<M>) -> ChangeEvent<Pair<K, V>>
+where
+    M: Into<Pair<K, V>>,
+{
+    match ev {
+        ChangeEvent::InsertAt {
+            event_id,
+            max_value,
+            value,
+            index,
+        } => ChangeEvent::InsertAt {
+            event_id,
+            max_value: max_value.into(),
+            value: value.into(),
+            index,
+        },
+        ChangeEvent::RemoveAt {
+            event_id,
+            max_value,
+            value,
+            index,
+        } => ChangeEvent::RemoveAt {
+            event_id,
+            max_value: max_value.into(),
+            value: value.into(),
+            index,
+        },
+        ChangeEvent::CreateNode { event_id, max_value } => ChangeEvent::CreateNode {
+            event_id,
+            max_value: max_value.into(),
+        },
+        ChangeEvent::RemoveNode { event_id, max_value } => ChangeEvent::RemoveNode {
+            event_id,
+            max_value: max_value.into(),
+        },
+        ChangeEvent::SplitNode {
+            event_id,
+            max_value,
+            split_index,
+        } => ChangeEvent::SplitNode {
+            event_id,
+            max_value: max_value.into(),
+            split_index,
+        },
+    }
+}
+
+#[cfg(feature = "multimap")]
+impl<K, V> From<ChangeEvent<RandomMultiPair<K, V>>> for ChangeEvent<Pair<K, V>> {
+    fn from(ev: ChangeEvent<RandomMultiPair<K, V>>) -> Self {
+        multipair_change_event_into_pair(ev)
+    }
+}
+
+#[cfg(feature = "multimap")]
+impl<K, V> From<ChangeEvent<OrdMultiPair<K, V>>> for ChangeEvent<Pair<K, V>> {
+    fn from(ev: ChangeEvent<OrdMultiPair<K, V>>) -> Self {
+        multipair_change_event_into_pair(ev)
     }
 }

--- a/src/concurrent/multimap.rs
+++ b/src/concurrent/multimap.rs
@@ -1,189 +1,148 @@
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::sync::Arc;
-use std::{borrow::Borrow, iter::FusedIterator, ops::RangeBounds};
+use std::{borrow::Borrow, iter::FusedIterator, ops::{Bound, RangeBounds}};
 
 use parking_lot::Mutex;
 
 use crate::core::node::NodeLike;
-use crate::{cdc::change::ChangeEvent, core::multipair::MultiPair};
+use crate::{cdc::change::ChangeEvent, core::multipair::{MultiPair, MultiPairLike, MultiPairRemoveHelper}};
 
 use super::set::BTreeSet;
 
 #[derive(Debug)]
-pub struct BTreeMultiMap<K, V, Node = Vec<MultiPair<K, V>>>
+pub struct BTreeMultiMap<K, V, Node = Vec<MultiPair<K, V>>, M = MultiPair<K, V>>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
-    pub(crate) set: BTreeSet<MultiPair<K, V>, Node>,
+    pub(crate) set: BTreeSet<M, Node>,
+    marker: PhantomData<(K, V)>,
 }
 
-impl<K, V, Node> Default for BTreeMultiMap<K, V, Node>
+impl<K, V, Node, M> Default for BTreeMultiMap<K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     fn default() -> Self {
         Self {
             set: Default::default(),
+            marker: PhantomData,
         }
     }
 }
 
-pub struct Iter<'a, K, V, Node>
+pub struct Iter<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
-    inner: super::set::Iter<'a, MultiPair<K, V>, Node>,
+    inner: super::set::Iter<'a, M, Node>,
+    marker: PhantomData<(K, V)>,
 }
 
-impl<'a, K, V, Node> Iterator for Iter<'a, K, V, Node>
+impl<'a, K, V, Node, M> Iterator for Iter<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(entry) = self.inner.next() {
-            return Some((&entry.key, &entry.value));
+            return Some((entry.key(), entry.value()));
         }
 
         None
     }
 }
 
-impl<'a, K, V, Node> DoubleEndedIterator for Iter<'a, K, V, Node>
+impl<'a, K, V, Node, M> DoubleEndedIterator for Iter<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         if let Some(entry) = self.inner.next_back() {
-            return Some((&entry.key, &entry.value));
+            return Some((entry.key(), entry.value()));
         }
 
         None
     }
 }
 
-impl<'a, K, V, Node> FusedIterator for Iter<'a, K, V, Node>
+impl<'a, K, V, Node, M> FusedIterator for Iter<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
 }
 
-pub struct RawRange<'a, K, V, Node>
+pub struct Range<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
-    inner: super::set::Range<'a, MultiPair<K, V>, Node>,
+    inner: super::set::Range<'a, M, Node>,
+    marker: PhantomData<(K, V)>,
 }
 
-impl<'a, K, V, Node> Iterator for RawRange<'a, K, V, Node>
+impl<'a, K, V, Node, M> Iterator for Range<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
-{
-    type Item = (&'a K, &'a u64, &'a V);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(entry) = self.inner.next() {
-            return Some((&entry.key, &entry.discriminator, &entry.value));
-        }
-
-        None
-    }
-}
-
-impl<'a, K, V, Node> DoubleEndedIterator for RawRange<'a, K, V, Node>
-where
-    K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
-{
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if let Some(entry) = self.inner.next_back() {
-            return Some((&entry.key, &entry.discriminator, &entry.value));
-        }
-
-        None
-    }
-}
-
-impl<'a, K, V, Node> FusedIterator for RawRange<'a, K, V, Node>
-where
-    K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
-{
-}
-
-pub struct Range<'a, K, V, Node>
-where
-    K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
-{
-    inner: RawRange<'a, K, V, Node>,
-}
-
-impl<'a, K, V, Node> Iterator for Range<'a, K, V, Node>
-where
-    K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(raw_entry) = self.inner.next() {
-            return Some((&raw_entry.0, &raw_entry.2));
-        }
-
-        None
+        self.inner.next().map(|entry| (entry.key(), entry.value()))
     }
 }
 
-impl<'a, K, V, Node> DoubleEndedIterator for Range<'a, K, V, Node>
+impl<'a, K, V, Node, M> DoubleEndedIterator for Range<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if let Some(raw_entry) = self.inner.next_back() {
-            return Some((&raw_entry.0, &raw_entry.2));
-        }
-
-        None
+        self.inner.next_back().map(|entry| (entry.key(), entry.value()))
     }
 }
 
-impl<'a, K, V, Node> FusedIterator for Range<'a, K, V, Node>
+impl<'a, K, V, Node, M> FusedIterator for Range<'a, K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
 }
 
-impl<K, V, Node> BTreeMultiMap<K, V, Node>
+impl<K, V, Node, M> BTreeMultiMap<K, V, Node, M>
 where
     K: Debug + Send + Ord + Clone + 'static,
-    V: Debug + Send + Clone + PartialEq + 'static,
-    Node: NodeLike<MultiPair<K, V>> + Send + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
 {
     /// Makes a new, empty, persistent `BTreeMultiMap`.
     ///
@@ -202,6 +161,7 @@ where
     pub fn new() -> Self {
         Self {
             set: Default::default(),
+            marker: PhantomData,
         }
     }
     /// Makes a new, empty `BTreeMultiMap` with the given maximum node size. Allocates one vec with
@@ -216,6 +176,7 @@ where
     pub fn with_maximum_node_size(node_capacity: usize) -> Self {
         Self {
             set: BTreeSet::with_maximum_node_size(node_capacity),
+            marker: PhantomData,
         }
     }
     /// Adds full [`Node`] to this multiset. [`Node`] should be correct node with
@@ -249,29 +210,20 @@ where
     /// ```
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
-        MultiPair<K, V>: Borrow<Q> + Ord,
+        M: Borrow<Q>,
         Q: Ord + ?Sized,
     {
         self.set.contains(key)
     }
-    fn _range<Q, R>(&self, range: R) -> Range<'_, K, V, Node>
+    fn _range<Q, R>(&self, range: R) -> Range<'_, K, V, Node, M>
     where
-        MultiPair<K, V>: Borrow<Q> + Ord,
+        M: Borrow<Q>,
         Q: Ord + ?Sized,
         R: RangeBounds<Q>,
     {
         Range {
-            inner: RawRange {
-                inner: super::set::BTreeSet::range(&self.set, range),
-            },
-        }
-    }
-    fn raw_get(&self, key: &K) -> RawRange<'_, K, V, Node> {
-        let infimum = MultiPair::with_infimum(key.clone());
-        let supremum = MultiPair::with_supremum(key.clone());
-
-        RawRange {
-            inner: self.set.range(infimum..supremum),
+            inner: super::set::BTreeSet::range(&self.set, range),
+            marker: PhantomData,
         }
     }
     /// Constructs a double-ended iterator over all key value pairs with the given key in the map.
@@ -290,15 +242,11 @@ where
     /// assert_eq!(all_with_key.len(), 2);
     /// assert_eq!(all_with_key, vec![(&1, &"a"), (&1, &"b")].into_iter().collect::<BTreeSet<_>>());
     /// ```
-    pub fn get(&self, key: &K) -> Range<'_, K, V, Node> {
-        let infimum = MultiPair::with_infimum(key.clone());
-        let supremum = MultiPair::with_supremum(key.clone());
-
-        Range {
-            inner: RawRange {
-                inner: self.set.range(infimum..supremum),
-            },
-        }
+    pub fn get(&self, key: &K) -> Range<'_, K, V, Node, M>
+    where
+        M: Borrow<K>,
+    {
+        self._range((Bound::Included(key), Bound::Included(key)))
     }
     /// Inserts a key-value pair into the multi map.
     ///
@@ -317,23 +265,23 @@ where
     /// assert_eq!(map.insert(37, "c"), None);
     /// ```
     pub fn insert(&self, key: K, value: V) -> Option<V> {
-        let new_entry = MultiPair::new(key, value);
+        let new_entry = M::new(key, value);
 
         self.set
             .put_cdc(new_entry)
             .0
-            .and_then(|pair| Some(pair.value))
+            .map(|pair| pair.into().1)
     }
     /// Inserts a key-value pair into the map and returns old value (if it was
     /// already in set) with [`ChangeEvent`]'s that describes this insert
     /// action.
     #[cfg(feature = "cdc")]
-    pub fn insert_cdc(&self, key: K, value: V) -> (Option<V>, Vec<ChangeEvent<MultiPair<K, V>>>) {
-        let new_entry = MultiPair::new(key, value);
+    pub fn insert_cdc(&self, key: K, value: V) -> (Option<V>, Vec<ChangeEvent<M>>) {
+        let new_entry = M::new(key, value);
 
         let (old_value, cdc) = self.set.put_cdc(new_entry);
 
-        (old_value.and_then(|pair| Some(pair.value)), cdc)
+        (old_value.map(|pair| pair.into().1), cdc)
     }
     /// Removes some key from the map that matches the given key, returning the
     /// key and the value if the key was previously in the map.
@@ -361,82 +309,25 @@ where
     /// ```
     pub fn remove_some<Q>(&self, key: &Q) -> Option<(K, V)>
     where
-        MultiPair<K, V>: Borrow<Q> + Ord,
+        M: Borrow<Q>,
         Q: Ord + ?Sized,
     {
         self.set
             .remove(key)
-            .and_then(|pair| Some((pair.key, pair.value)))
+            .map(Into::into)
     }
     /// Removes some key from the map that matches the given key, returning the
     /// key and the value if the key was previously in the map with
     /// [`ChangeEvent`]'s describing this `remove_some` action.
     #[cfg(feature = "cdc")]
-    pub fn remove_some_cdc<Q>(&self, key: &Q) -> (Option<(K, V)>, Vec<ChangeEvent<MultiPair<K, V>>>)
+    pub fn remove_some_cdc<Q>(&self, key: &Q) -> (Option<(K, V)>, Vec<ChangeEvent<M>>)
     where
-        MultiPair<K, V>: Borrow<Q> + Ord,
+        M: Borrow<Q>,
         Q: Ord + ?Sized,
     {
         let (old_value, cdc) = self.set.remove_cdc(key);
 
-        (old_value.and_then(|pair| Some((pair.key, pair.value))), cdc)
-    }
-    /// Removes a specific key-value pair from the map returning the key and the value if the key
-    /// was previously in the map.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// use indexset::concurrent::multimap::BTreeMultiMap;
-    ///
-    /// let map = BTreeMultiMap::<usize, &str>::new();
-    /// map.insert(1, "b");
-    /// map.insert(1, "a");
-    ///
-    /// assert_eq!(map.remove(&1, &"a"), Some((1, "a")));
-    /// assert_eq!(map.remove(&1, &"b"), Some((1, "b")));
-    /// ```
-    pub fn remove(&self, key: &K, value: &V) -> Option<(K, V)> {
-        let discriminant_to_remove = self.raw_get(&key).find(|pair| pair.2 == value);
-        if let Some(discriminant_to_remove) = discriminant_to_remove {
-            let pair_to_remove = MultiPair {
-                key: discriminant_to_remove.0.clone(),
-                value: discriminant_to_remove.2.clone(),
-                discriminator: *discriminant_to_remove.1,
-            };
-
-            return self
-                .set
-                .remove(&pair_to_remove)
-                .and_then(|pair| Some((pair.key, pair.value)));
-        }
-
-        None
-    }
-    /// Removes a specific key-value pair from the map returning the key and the
-    /// value if the key was previously in the map with [`ChangeEvent`]'s
-    /// describing this `remove_some` action.
-    #[cfg(feature = "cdc")]
-    pub fn remove_cdc(
-        &self,
-        key: &K,
-        value: &V,
-    ) -> (Option<(K, V)>, Vec<ChangeEvent<MultiPair<K, V>>>) {
-        let discriminant_to_remove = self.raw_get(&key).find(|pair| pair.2 == value);
-        if let Some(discriminant_to_remove) = discriminant_to_remove {
-            let pair_to_remove = MultiPair {
-                key: discriminant_to_remove.0.clone(),
-                value: discriminant_to_remove.2.clone(),
-                discriminator: *discriminant_to_remove.1,
-            };
-
-            let (res, evs) = self.set.remove_cdc(&pair_to_remove);
-            return (res.map(|pair| (pair.key, pair.value)), evs);
-        }
-
-        (None, vec![])
+        (old_value.map(Into::into), cdc)
     }
     /// Returns the number of elements in the map.
     ///
@@ -519,9 +410,10 @@ where
     /// let (first_key, first_value) = map.iter().next().unwrap();
     /// assert_eq!((*first_key, *first_value), (1, "a"));
     /// ```
-    pub fn iter(&self) -> Iter<'_, K, V, Node> {
+    pub fn iter(&self) -> Iter<'_, K, V, Node, M> {
         Iter {
             inner: self.set.iter(),
+            marker: PhantomData,
         }
     }
     /// Constructs a double-ended iterator over a sub-range of elements in the map.
@@ -553,39 +445,64 @@ where
     /// }
     /// assert_eq!(Some((&5, &"b")), map.range(4..).next());
     /// ```
-    pub fn range<R>(&self, range: R) -> Range<'_, K, V, Node>
+    pub fn range<R>(&self, range: R) -> Range<'_, K, V, Node, M>
     where
+        M: Borrow<K>,
         R: RangeBounds<K>,
     {
-        let start_bound = range.start_bound();
-        let adjusted_start_bound = match start_bound {
-            std::ops::Bound::Included(start) => {
-                std::ops::Bound::Included(MultiPair::with_infimum(start.clone()))
-            }
-            std::ops::Bound::Excluded(start) => {
-                std::ops::Bound::Excluded(MultiPair::with_supremum(start.clone()))
-            }
-            _ => std::ops::Bound::Unbounded,
-        };
-        let end_bound = range.end_bound();
-        let adjusted_end_bound = match end_bound {
-            std::ops::Bound::Included(end) => {
-                std::ops::Bound::Included(MultiPair::with_supremum(end.clone()))
-            }
-            std::ops::Bound::Excluded(end) => {
-                std::ops::Bound::Excluded(MultiPair::with_infimum(end.clone()))
-            }
-            _ => std::ops::Bound::Unbounded,
-        };
+        self._range(range)
+    }
+}
 
-        self._range((adjusted_start_bound, adjusted_end_bound))
+impl<K, V, Node, M> BTreeMultiMap<K, V, Node, M>
+where
+    K: Debug + Send + Ord + Clone + 'static,
+    V: Debug + Send + Clone + 'static,
+    M: MultiPairLike<K, V> + MultiPairRemoveHelper<K, V> + Debug + Clone + Send + 'static,
+    Node: NodeLike<M> + Send + 'static,
+{
+    /// Removes a specific key-value pair from the map returning the key and the value if the key
+    /// was previously in the map.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use indexset::concurrent::multimap::BTreeMultiMap;
+    ///
+    /// let map = BTreeMultiMap::<usize, &str>::new();
+    /// map.insert(1, "b");
+    /// map.insert(1, "a");
+    ///
+    /// assert_eq!(map.remove(&1, &"a"), Some((1, "a")));
+    /// assert_eq!(map.remove(&1, &"b"), Some((1, "b")));
+    /// ```
+    pub fn remove(&self, key: &K, value: &V) -> Option<(K, V)> {
+        M::remove_from(&self.set, key, value)
+    }
+
+    /// Removes a specific key-value pair from the map returning the key and the
+    /// value if the key was previously in the map with [`ChangeEvent`]'s
+    /// describing this `remove_some` action.
+    #[cfg(feature = "cdc")]
+    pub fn remove_cdc(
+        &self,
+        key: &K,
+        value: &V,
+    ) -> (Option<(K, V)>, Vec<ChangeEvent<M>>) {
+        M::remove_cdc_from(&self.set, key, value)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::BTreeMultiMap;
+    use crate::core::multipair::{MultiPairLike, OrdMultiPair, RandomMultiPair};
     use crate::BTreeSet;
+    use std::borrow::Borrow;
+    use std::fmt::Debug;
+    use std::ops::Bound::{Excluded, Unbounded};
 
     #[test]
     fn test_insert_works_as_expected() {
@@ -633,6 +550,10 @@ mod tests {
             .into_iter()
             .collect::<BTreeSet<_>>();
         assert_eq!(all_actual_pairs, all_expected_pairs);
+
+        let all_ranged_pairs = map.range(1..2).map(|(k, v)| (*k, *v)).collect::<BTreeSet<_>>();
+        assert_eq!(all_ranged_pairs, all_expected_pairs);
+        assert!(map.range(1..1).next().is_none());
     }
 
     #[test]
@@ -657,10 +578,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_range_works_as_expected() {
+    fn assert_range_works_as_expected<M>()
+    where
+        M: MultiPairLike<usize, &'static str> + Borrow<usize> + Debug + Clone + Send + 'static,
+    {
         let maximum_node_size = 3;
-        let map = BTreeMultiMap::<usize, &str>::with_maximum_node_size(maximum_node_size);
+        let map = BTreeMultiMap::<usize, &'static str, Vec<M>, M>::with_maximum_node_size(
+            maximum_node_size,
+        );
 
         map.insert(1usize, "a");
         map.insert(1usize, "b");
@@ -687,7 +612,7 @@ mod tests {
             reverse_range,
             vec![(&3, &"e"), (&2, &"d"), (&2, &"c"), (&1, &"b"), (&1, &"a"),]
                 .into_iter()
-                .collect::<BTreeSet<_>>()
+            .collect::<BTreeSet<_>>()
         );
 
         let empty_range = map.range(5..).collect::<BTreeSet<_>>();
@@ -695,9 +620,52 @@ mod tests {
     }
 
     #[test]
-    fn test_get_works_as_expected() {
+    fn test_range_works_as_expected() {
+        assert_range_works_as_expected::<RandomMultiPair<usize, &'static str>>();
+        assert_range_works_as_expected::<OrdMultiPair<usize, &'static str>>();
+    }
+
+    fn assert_range_excludes_values_at_bounds<M>()
+    where
+        M: MultiPairLike<usize, &'static str> + Borrow<usize> + Debug + Clone + Send + 'static,
+    {
+        let map = BTreeMultiMap::<usize, &'static str, Vec<M>, M>::with_maximum_node_size(10);
+
+        map.insert(1usize, "a");
+        map.insert(1usize, "b");
+        map.insert(2usize, "c");
+        map.insert(2usize, "d");
+        map.insert(3usize, "e");
+        map.insert(3usize, "f");
+
+        assert_eq!(
+            map.range((Excluded(&1), Unbounded)).collect::<BTreeSet<_>>(),
+            vec![(&2, &"c"), (&2, &"d"), (&3, &"e"), (&3, &"f")]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+        );
+        assert_eq!(
+            map.range((Unbounded, Excluded(&3))).collect::<BTreeSet<_>>(),
+            vec![(&1, &"a"), (&1, &"b"), (&2, &"c"), (&2, &"d")]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+        );
+    }
+
+    #[test]
+    fn test_range_excludes_all_values_at_bounds() {
+        assert_range_excludes_values_at_bounds::<RandomMultiPair<usize, &'static str>>();
+        assert_range_excludes_values_at_bounds::<OrdMultiPair<usize, &'static str>>();
+    }
+
+    fn assert_get_works_as_expected<M>()
+    where
+        M: MultiPairLike<usize, &'static str> + Borrow<usize> + Debug + Clone + Send + 'static,
+    {
         let maximum_node_size = 10;
-        let map = BTreeMultiMap::<usize, &str>::with_maximum_node_size(maximum_node_size);
+        let map = BTreeMultiMap::<usize, &'static str, Vec<M>, M>::with_maximum_node_size(
+            maximum_node_size,
+        );
 
         map.insert(1usize, "a");
         map.insert(1usize, "b");
@@ -737,6 +705,12 @@ mod tests {
                 .into_iter()
                 .collect::<BTreeSet<_>>()
         );
+    }
+
+    #[test]
+    fn test_get_works_as_expected() {
+        assert_get_works_as_expected::<RandomMultiPair<usize, &'static str>>();
+        assert_get_works_as_expected::<OrdMultiPair<usize, &'static str>>();
     }
 
     #[test]

--- a/src/core/multipair.rs
+++ b/src/core/multipair.rs
@@ -1,189 +1,42 @@
-use std::fmt::Debug;
-use std::{borrow::Borrow, mem::MaybeUninit};
+use crate::cdc::change::ChangeEvent;
+use crate::concurrent::set::BTreeSet;
+use crate::core::node::NodeLike;
 
-use core::cmp::Ordering;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use fastrand;
+pub mod ord;
+pub mod random;
 
-use crate::core::pair::Pair;
+pub use ord::OrdMultiPair;
+pub use random::RandomMultiPair;
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Default, Clone, Hash)]
-pub struct MultiPair<K, V> {
-    pub key: K,
-    pub value: V,
-    pub discriminator: u64,
+pub type MultiPair<K, V> = RandomMultiPair<K, V>;
+
+/// Common contract for key-value pairs stored by `BTreeMultiMap`.
+///
+/// Implementations must order entries by key first: entries with the same key
+/// must form one contiguous range, while their representation may refine the
+/// order within that range.
+pub trait MultiPairLike<K, V>: Into<(K, V)> + Ord {
+    fn new(key: K, value: V) -> Self;
+    fn key(&self) -> &K;
+    fn value(&self) -> &V;
 }
 
-impl<K: Ord, V: PartialEq> MultiPair<K, V> {
-    pub fn new(key: K, value: V) -> Self {
-        Self { key, value, discriminator: fastrand::u64(..) }
-    }
-    pub fn with_infimum(key: K) -> Self {
-        Self { key, value: unsafe { MaybeUninit::uninit().assume_init() }, discriminator: INFIMUM }
-    }
-    pub fn with_supremum(key: K) -> Self {
-        Self { key, value: unsafe { MaybeUninit::uninit().assume_init() }, discriminator: SUPREMUM }
-    }
-}
-
-impl<K: Ord, V: PartialEq> Eq for MultiPair<K, V> {}
-
-impl<K: Ord, V: PartialEq> PartialEq<Self> for MultiPair<K, V> {
-    fn eq(&self, other: &Self) -> bool {
-        self.key.eq(&other.key) && self.value.eq(&other.value)
-    }
-}
-
-const INFIMUM: u64 = 0;
-const SUPREMUM: u64 = u64::MAX;
-
-impl<K: Ord, V: PartialEq> Ord for MultiPair<K, V> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match self.key.cmp(&other.key) {
-            Ordering::Equal => {
-                if (self.discriminator == INFIMUM || other.discriminator == INFIMUM) || (self.discriminator == SUPREMUM || other.discriminator == SUPREMUM) {
-                    return self.discriminator.cmp(&other.discriminator);
-                }
-
-                if self.value.eq(&other.value) {
-                    return Ordering::Equal;
-                }
-
-                self.discriminator.cmp(&other.discriminator)
-            },
-            ord => ord,
-        }
-    }
-}
-
-impl<K: Ord, V: PartialEq> PartialOrd for MultiPair<K, V> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<K: Ord, V: PartialEq> Borrow<K> for MultiPair<K, V> {
-    fn borrow(&self) -> &K {
-        &self.key
-    }
-}
-
-impl<K: Ord, V: PartialEq> From<Pair<K, V>> for MultiPair<K, V> {
-    fn from(pair: Pair<K, V>) -> Self {
-        MultiPair {
-            key: pair.key,
-            value: pair.value,
-            discriminator: fastrand::u64(..),
-        }
-    }
-}
-
-impl<K: Ord, V: PartialEq> From<MultiPair<K, V>> for Pair<K, V> {
-    fn from(pair: MultiPair<K, V>) -> Self {
-        Pair {
-            key: pair.key,
-            value: pair.value,
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::core::node::NodeLike;
-    use std::ops::Bound::*;
-
-    #[test]
-    fn borrow_test() {
-        let pair = MultiPair::new(1usize, 2usize);
-        assert_eq!(<MultiPair<usize, usize> as Borrow<usize>>::borrow(&pair), &1usize);
+/// Pair-specific exact-removal strategy used by `BTreeMultiMap`.
+pub trait MultiPairRemoveHelper<K, V> {
+    fn remove_from<Node>(set: &BTreeSet<Self, Node>, key: &K, value: &V) -> Option<(K, V)>
+    where
+        Self: Ord + Clone + 'static,
+        Node: NodeLike<Self> + Send + 'static,
+    {
+        Self::remove_cdc_from(set, key, value).0
     }
 
-    #[test]
-    fn eq_test() {
-        let pair_one = MultiPair::new(1usize, 2usize);
-        let pair_two = MultiPair::new(1usize, 3usize);
-        assert_ne!(pair_one, pair_two);
-    }
-
-    #[test]
-    fn node_like() {
-        let mut vec = Vec::new();
-        let p1 = MultiPair::new(1, "a");
-        let p2 = MultiPair::new(1, "b");
-        let p3 = MultiPair::new(2, "c");
-     
-        NodeLike::insert(&mut vec, p1.clone());
-        NodeLike::insert(&mut vec, p2.clone());
-        assert_eq!(vec.len(), 2); 
-
-        NodeLike::insert(&mut vec, p1.clone());
-        assert_eq!(vec.len(), 2);
-     
-        NodeLike::insert(&mut vec, p3.clone());
-        assert_eq!(vec.len(), 3);
-     }
-
-     #[test]
-     fn range_bounds() {
-        let mut vec = Vec::new();
-    
-        let p1a = MultiPair::new(1, "a");
-        let p1b = MultiPair::new(1, "b");
-        let p1c = MultiPair::new(1, "c");
-        let p2a = MultiPair::new(2, "a");
-        let p2b = MultiPair::new(2, "b");
-        let p3a = MultiPair::new(3, "a");
-        let p3b = MultiPair::new(3, "b");
-        let p3c = MultiPair::new(3, "c");
-        let p3d = MultiPair::new(3, "d");
-        let p4a = MultiPair::new(4, "a");
-
-        NodeLike::insert(&mut vec, p4a.clone());
-        NodeLike::insert(&mut vec, p1a.clone());
-        NodeLike::insert(&mut vec, p1c.clone());
-        NodeLike::insert(&mut vec, p1b.clone());
-        NodeLike::insert(&mut vec, p2b.clone());
-        NodeLike::insert(&mut vec, p2a.clone());
-        NodeLike::insert(&mut vec, p3a.clone());
-        NodeLike::insert(&mut vec, p3b.clone());
-        NodeLike::insert(&mut vec, p3d.clone());
-        NodeLike::insert(&mut vec, p3c.clone());
-        assert_eq!(vec.len(), 10);
-
-        let start_1 = vec.rank(Included(&MultiPair::with_infimum(1)), true).or_else(|| Some(0)).unwrap();
-        let end_1 = vec.rank(Excluded(&MultiPair::with_supremum(1)), true).unwrap();
-        let range_1 = &vec[start_1..=end_1];
-        assert_eq!(range_1.len(), 3);
-        assert!(range_1.contains(&p1a));
-        assert!(range_1.contains(&p1b));
-        assert!(range_1.contains(&p1c));
-
-        let end_2 = vec.rank(Excluded(&MultiPair::with_supremum(2)), true).unwrap();
-        let range_2 = &vec[start_1..=end_2];
-        assert_eq!(range_2.len(), 5);
-        assert!(range_2.contains(&p1a));
-        assert!(range_2.contains(&p1b));
-        assert!(range_2.contains(&p1c));
-        assert!(range_2.contains(&p2a));
-        assert!(range_2.contains(&p2b));
-        assert_ne!(range_2.contains(&p3a), true);
-
-        let start_3 = vec.rank(Included(&MultiPair::with_infimum(3)), true).unwrap() + 1;
-        let end_3 = vec.rank(Excluded(&MultiPair::with_supremum(3)), true).unwrap();
-        let range_3 = &vec[start_3..=end_3];
-        assert_eq!(range_3.len(), 4);
-        assert!(range_3.contains(&p3a));
-        assert!(range_3.contains(&p3b));
-        assert!(range_3.contains(&p3c));
-        assert!(range_3.contains(&p3d));
-
-        let start_4 = vec.rank(Included(&MultiPair::with_infimum(4)), true).unwrap() + 1;
-        let end_4 = vec.rank(Excluded(&MultiPair::with_supremum(4)), true).unwrap();
-        let range_4 = &vec[start_4..=end_4];
-        assert_eq!(range_4.len(), 1);
-        assert!(range_4.contains(&p4a));
-     }
+    fn remove_cdc_from<Node>(
+        set: &BTreeSet<Self, Node>,
+        key: &K,
+        value: &V,
+    ) -> (Option<(K, V)>, Vec<ChangeEvent<Self>>)
+    where
+        Self: Ord + Clone + 'static,
+        Node: NodeLike<Self> + Send + 'static;
 }

--- a/src/core/multipair/ord.rs
+++ b/src/core/multipair/ord.rs
@@ -1,0 +1,111 @@
+use std::borrow::Borrow;
+use std::fmt::Debug;
+
+use core::cmp::Ordering;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::cdc::change::ChangeEvent;
+use crate::concurrent::set::BTreeSet;
+use crate::core::node::NodeLike;
+use crate::core::pair::Pair;
+
+use super::{MultiPairLike, MultiPairRemoveHelper};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone, Hash)]
+pub struct OrdMultiPair<K, V> {
+    pub key: K,
+    pub value: V,
+}
+
+impl<K, V> OrdMultiPair<K, V> {
+    pub fn new(key: K, value: V) -> Self {
+        Self { key, value }
+    }
+}
+
+impl<K: Ord, V: Ord> Eq for OrdMultiPair<K, V> {}
+
+impl<K: Ord, V: Ord> PartialEq<Self> for OrdMultiPair<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key.eq(&other.key) && self.value.eq(&other.value)
+    }
+}
+
+impl<K: Ord, V: Ord> Ord for OrdMultiPair<K, V> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key.cmp(&other.key).then(self.value.cmp(&other.value))
+    }
+}
+
+impl<K: Ord, V: Ord> PartialOrd for OrdMultiPair<K, V> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K, V> Borrow<K> for OrdMultiPair<K, V> {
+    fn borrow(&self) -> &K {
+        &self.key
+    }
+}
+
+impl<K: Ord, V: Ord> MultiPairLike<K, V> for OrdMultiPair<K, V> {
+    fn new(key: K, value: V) -> Self {
+        Self::new(key, value)
+    }
+
+    fn key(&self) -> &K {
+        &self.key
+    }
+
+    fn value(&self) -> &V {
+        &self.value
+    }
+}
+
+impl<K, V> From<Pair<K, V>> for OrdMultiPair<K, V> {
+    fn from(pair: Pair<K, V>) -> Self {
+        OrdMultiPair {
+            key: pair.key,
+            value: pair.value,
+        }
+    }
+}
+
+impl<K, V> From<OrdMultiPair<K, V>> for Pair<K, V> {
+    fn from(pair: OrdMultiPair<K, V>) -> Self {
+        Pair {
+            key: pair.key,
+            value: pair.value,
+        }
+    }
+}
+
+impl<K, V> From<OrdMultiPair<K, V>> for (K, V) {
+    fn from(pair: OrdMultiPair<K, V>) -> Self {
+        (pair.key, pair.value)
+    }
+}
+
+impl<K, V> MultiPairRemoveHelper<K, V> for OrdMultiPair<K, V>
+where
+    K: Debug + Send + Ord + Clone + 'static,
+    V: Debug + Send + Ord + Clone + 'static,
+{
+    fn remove_cdc_from<Node>(
+        set: &BTreeSet<Self, Node>,
+        key: &K,
+        value: &V,
+    ) -> (Option<(K, V)>, Vec<ChangeEvent<Self>>)
+    where
+        Self: Ord + Clone + 'static,
+        Node: NodeLike<Self> + Send + 'static,
+    {
+        let pair_to_remove = OrdMultiPair::new(key.clone(), value.clone());
+        let (res, evs) = set.remove_cdc(&pair_to_remove);
+
+        (res.map(Into::into), evs)
+    }
+}

--- a/src/core/multipair/random.rs
+++ b/src/core/multipair/random.rs
@@ -1,0 +1,225 @@
+use std::borrow::Borrow;
+use std::fmt::Debug;
+use std::ops::Bound;
+
+use core::cmp::Ordering;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::cdc::change::ChangeEvent;
+use crate::concurrent::set::BTreeSet;
+use crate::core::node::NodeLike;
+use crate::core::pair::Pair;
+
+use super::{MultiPairLike, MultiPairRemoveHelper};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, Clone, Hash)]
+pub struct RandomMultiPair<K, V> {
+    pub key: K,
+    pub value: V,
+    pub discriminator: u64,
+}
+
+impl<K, V> RandomMultiPair<K, V> {
+    pub fn new(key: K, value: V) -> Self {
+        Self { key, value, discriminator: fastrand::u64(..) }
+    }
+
+}
+
+impl<K: Ord, V: PartialEq> Eq for RandomMultiPair<K, V> {}
+
+impl<K: Ord, V: PartialEq> PartialEq<Self> for RandomMultiPair<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key.eq(&other.key) && self.value.eq(&other.value)
+    }
+}
+
+impl<K: Ord, V: PartialEq> Ord for RandomMultiPair<K, V> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.key.cmp(&other.key) {
+            Ordering::Equal if self.value.eq(&other.value) => Ordering::Equal,
+            Ordering::Equal => self.discriminator.cmp(&other.discriminator),
+            ord => ord,
+        }
+    }
+}
+
+impl<K: Ord, V: PartialEq> PartialOrd for RandomMultiPair<K, V> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K, V> Borrow<K> for RandomMultiPair<K, V> {
+    fn borrow(&self) -> &K {
+        &self.key
+    }
+}
+
+impl<K: Ord, V: PartialEq> MultiPairLike<K, V> for RandomMultiPair<K, V> {
+    fn new(key: K, value: V) -> Self {
+        Self::new(key, value)
+    }
+
+    fn key(&self) -> &K {
+        &self.key
+    }
+
+    fn value(&self) -> &V {
+        &self.value
+    }
+}
+
+impl<K, V> From<Pair<K, V>> for RandomMultiPair<K, V> {
+    fn from(pair: Pair<K, V>) -> Self {
+        RandomMultiPair {
+            key: pair.key,
+            value: pair.value,
+            discriminator: fastrand::u64(..),
+        }
+    }
+}
+
+impl<K, V> From<RandomMultiPair<K, V>> for Pair<K, V> {
+    fn from(pair: RandomMultiPair<K, V>) -> Self {
+        Pair {
+            key: pair.key,
+            value: pair.value,
+        }
+    }
+}
+
+impl<K, V> From<RandomMultiPair<K, V>> for (K, V) {
+    fn from(pair: RandomMultiPair<K, V>) -> Self {
+        (pair.key, pair.value)
+    }
+}
+
+impl<K, V> MultiPairRemoveHelper<K, V> for RandomMultiPair<K, V>
+where
+    K: Debug + Send + Ord + Clone + 'static,
+    V: Debug + Send + Clone + PartialEq + 'static,
+{
+    fn remove_cdc_from<Node>(
+        set: &BTreeSet<Self, Node>,
+        key: &K,
+        value: &V,
+    ) -> (Option<(K, V)>, Vec<ChangeEvent<Self>>)
+    where
+        Self: Ord + Clone + 'static,
+        Node: NodeLike<Self> + Send + 'static,
+    {
+        let pair_to_remove = set
+            .range::<K, _>((Bound::Included(key), Bound::Included(key)))
+            .find(|pair| pair.key == *key && pair.value == *value)
+            .cloned();
+
+        if let Some(pair_to_remove) = pair_to_remove {
+            let (res, evs) = set.remove_cdc(&pair_to_remove);
+            return (res.map(Into::into), evs);
+        }
+
+        (None, vec![])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::core::node::NodeLike;
+    use std::ops::Bound::*;
+
+    #[test]
+    fn borrow_test() {
+        let pair = RandomMultiPair::new(1usize, 2usize);
+        assert_eq!(<RandomMultiPair<usize, usize> as Borrow<usize>>::borrow(&pair), &1usize);
+    }
+
+    #[test]
+    fn eq_test() {
+        let pair_one = RandomMultiPair::new(1usize, 2usize);
+        let pair_two = RandomMultiPair::new(1usize, 3usize);
+        assert_ne!(pair_one, pair_two);
+    }
+
+    #[test]
+    fn node_like() {
+        let mut vec = Vec::new();
+        let p1 = RandomMultiPair::new(1, "a");
+        let p2 = RandomMultiPair::new(1, "b");
+        let p3 = RandomMultiPair::new(2, "c");
+     
+        NodeLike::insert(&mut vec, p1.clone());
+        NodeLike::insert(&mut vec, p2.clone());
+        assert_eq!(vec.len(), 2); 
+
+        NodeLike::insert(&mut vec, p1.clone());
+        assert_eq!(vec.len(), 2);
+     
+        NodeLike::insert(&mut vec, p3.clone());
+        assert_eq!(vec.len(), 3);
+     }
+
+     #[test]
+     fn range_bounds() {
+        let mut vec = Vec::new();
+    
+        let p1a = RandomMultiPair::new(1, "a");
+        let p1b = RandomMultiPair::new(1, "b");
+        let p1c = RandomMultiPair::new(1, "c");
+        let p2a = RandomMultiPair::new(2, "a");
+        let p2b = RandomMultiPair::new(2, "b");
+        let p3a = RandomMultiPair::new(3, "a");
+        let p3b = RandomMultiPair::new(3, "b");
+        let p3c = RandomMultiPair::new(3, "c");
+        let p3d = RandomMultiPair::new(3, "d");
+        let p4a = RandomMultiPair::new(4, "a");
+
+        NodeLike::insert(&mut vec, p4a.clone());
+        NodeLike::insert(&mut vec, p1a.clone());
+        NodeLike::insert(&mut vec, p1c.clone());
+        NodeLike::insert(&mut vec, p1b.clone());
+        NodeLike::insert(&mut vec, p2b.clone());
+        NodeLike::insert(&mut vec, p2a.clone());
+        NodeLike::insert(&mut vec, p3a.clone());
+        NodeLike::insert(&mut vec, p3b.clone());
+        NodeLike::insert(&mut vec, p3d.clone());
+        NodeLike::insert(&mut vec, p3c.clone());
+        assert_eq!(vec.len(), 10);
+
+        let start_1 = vec.rank(Included(&1), true).map_or(0, |rank| rank + 1);
+        let end_1 = vec.rank(Excluded(&1), true).unwrap();
+        let range_1 = &vec[start_1..=end_1];
+        assert_eq!(range_1.len(), 3);
+        assert!(range_1.contains(&p1a));
+        assert!(range_1.contains(&p1b));
+        assert!(range_1.contains(&p1c));
+
+        let end_2 = vec.rank(Excluded(&2), true).unwrap();
+        let range_2 = &vec[start_1..=end_2];
+        assert_eq!(range_2.len(), 5);
+        assert!(range_2.contains(&p1a));
+        assert!(range_2.contains(&p1b));
+        assert!(range_2.contains(&p1c));
+        assert!(range_2.contains(&p2a));
+        assert!(range_2.contains(&p2b));
+        assert_ne!(range_2.contains(&p3a), true);
+
+        let start_3 = vec.rank(Included(&3), true).unwrap() + 1;
+        let end_3 = vec.rank(Excluded(&3), true).unwrap();
+        let range_3 = &vec[start_3..=end_3];
+        assert_eq!(range_3.len(), 4);
+        assert!(range_3.contains(&p3a));
+        assert!(range_3.contains(&p3b));
+        assert!(range_3.contains(&p3c));
+        assert!(range_3.contains(&p3d));
+
+        let start_4 = vec.rank(Included(&4), true).unwrap() + 1;
+        let end_4 = vec.rank(Excluded(&4), true).unwrap();
+        let range_4 = &vec[start_4..=end_4];
+        assert_eq!(range_4.len(), 1);
+        assert!(range_4.contains(&p4a));
+     }
+}

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -40,7 +40,9 @@ pub trait NodeLike<T: Ord> {
     #[allow(dead_code)]
     fn min(&self) -> Option<&T>;
     #[allow(dead_code)]
-    fn iter<'a>(&'a self) -> std::slice::Iter<'a, T> where T: 'a;
+    fn iter<'a>(&'a self) -> std::slice::Iter<'a, T>
+    where
+        T: 'a;
 }
 
 #[inline]
@@ -78,14 +80,18 @@ enum Direction<'a, T> {
 }
 
 #[inline]
-fn compute_positions_to_skip<Q, T: Ord>(haystack: &[T], bound: std::ops::Bound<&Q>, forward: bool) -> Option<usize>
+fn compute_positions_to_skip<Q, T: Ord>(
+    haystack: &[T],
+    bound: std::ops::Bound<&Q>,
+    forward: bool,
+) -> Option<usize>
 where
     T: Borrow<Q> + Ord,
     Q: Ord + ?Sized,
 {
     match bound {
         // If the bound is unbounded, then no skipping is needed
-        std::ops::Bound::Unbounded => { None }
+        std::ops::Bound::Unbounded => None,
         std::ops::Bound::Included(value) | std::ops::Bound::Excluded(value) => {
             let mut positions_to_skip = -1;
             let iter = if forward {
@@ -99,9 +105,12 @@ where
                     for item in iter {
                         match item.borrow().cmp(&value) {
                             Ordering::Less => positions_to_skip += 1,
-                                Ordering::Equal => match bound {
+                            Ordering::Equal => match bound {
                                 std::ops::Bound::Included(_) => break,
-                                std::ops::Bound::Excluded(_) => { positions_to_skip += 1; break },
+                                std::ops::Bound::Excluded(_) => {
+                                    positions_to_skip += 1;
+                                    continue;
+                                }
                                 _ => unreachable!(),
                             },
                             Ordering::Greater => break,
@@ -114,7 +123,10 @@ where
                             Ordering::Greater => positions_to_skip += 1,
                             Ordering::Equal => match bound {
                                 std::ops::Bound::Included(_) => break,
-                                std::ops::Bound::Excluded(_) => { positions_to_skip += 1; break },
+                                std::ops::Bound::Excluded(_) => {
+                                    positions_to_skip += 1;
+                                    continue;
+                                }
                                 _ => unreachable!(),
                             },
                             Ordering::Less => break,
@@ -227,7 +239,8 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
     }
     #[inline]
     fn iter<'a>(&'a self) -> std::slice::Iter<'a, T>
-    where T: 'a
+    where
+        T: 'a,
     {
         self.deref().iter()
     }
@@ -237,40 +250,149 @@ impl<T: Ord> NodeLike<T> for Vec<T> {
 mod tests {
     use super::*;
 
+    #[derive(Eq, Ord, PartialEq, PartialOrd)]
+    struct KeyThenValue(usize, &'static str);
+
+    impl Borrow<usize> for KeyThenValue {
+        fn borrow(&self) -> &usize {
+            &self.0
+        }
+    }
+
     #[test]
     fn test_search_bound() {
         let vec = vec![1, 3, 5, 7, 9];
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, false), None);
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Unbounded, false),
+            None
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), true), Some(1));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), true), Some(3));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), true), Some(4));
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), true),
+            Some(1)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), true),
+            Some(3)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), true),
+            Some(4)
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), true), Some(0));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), true), Some(2));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), true), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), true), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), true), Some(4));
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), true),
+            Some(0)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), true),
+            Some(2)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), true),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), true),
+            Some(4)
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), false), Some(3));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), false), Some(1));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), false), None);
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&1), false),
+            Some(3)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&5), false),
+            Some(1)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&9), false),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&0), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Included(&10), false),
+            None
+        );
 
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), false), Some(2));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), false), Some(0));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), false), Some(4));
-        assert_eq!(compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&1), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&5), false),
+            Some(2)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&9), false),
+            Some(0)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&0), false),
+            Some(4)
+        );
+        assert_eq!(
+            compute_positions_to_skip(&vec, std::ops::Bound::Excluded(&10), false),
+            None
+        );
 
         let empty: Vec<i32> = vec![];
-        assert_eq!(compute_positions_to_skip(&empty, std::ops::Bound::Included(&1), true), None);
-        assert_eq!(compute_positions_to_skip(&empty, std::ops::Bound::Excluded(&1), false), None);
+        assert_eq!(
+            compute_positions_to_skip(&empty, std::ops::Bound::Included(&1), true),
+            None
+        );
+        assert_eq!(
+            compute_positions_to_skip(&empty, std::ops::Bound::Excluded(&1), false),
+            None
+        );
     }
 
+    #[test]
+    fn excluded_borrowed_bound_skips_all_equal_keys() {
+        let node = vec![
+            KeyThenValue(1, "a"),
+            KeyThenValue(1, "b"),
+            KeyThenValue(2, "a"),
+        ];
+
+        assert_eq!(
+            compute_positions_to_skip(&node, std::ops::Bound::Excluded(&1), true),
+            Some(1),
+        );
+    }
+
+    #[test]
+    fn excluded_borrowed_end_bound_skips_all_equal_keys() {
+        let node = vec![
+            KeyThenValue(1, "a"),
+            KeyThenValue(2, "a"),
+            KeyThenValue(2, "b"),
+            KeyThenValue(3, "a"),
+        ];
+
+        assert_eq!(
+            compute_positions_to_skip(&node, std::ops::Bound::Excluded(&2), false),
+            Some(2),
+        );
+    }
 }


### PR DESCRIPTION
- add `OrdMultiPair` implementation which sorts by `V: Ord`
- rework existing `MultiPair` as `RandomMultiPair`
- add benches to compare two implementations